### PR TITLE
Adding a PR-705 toolbox to PTB-3

### DIFF
--- a/Psychtoolbox/PsychHardware/CMCheckInit.m
+++ b/Psychtoolbox/PsychHardware/CMCheckInit.m
@@ -14,6 +14,7 @@ function CMCheckInit(meterType, PortString)
 % meterType 3 is the CRS Colorimeter
 % meterType 4 is the PR655
 % meterType 5 is the PR670
+% meterType 6 is the PR705
 %
 % For the PR-series colorimeters, 'PortString' is the optional name of a
 % device string for the serial port or Serial-over-USB port to which the
@@ -52,6 +53,7 @@ function CMCheckInit(meterType, PortString)
 % 7/16/12  dhb      Choose right global default for 64-bit Matlab.  Hope I
 %                   did this in a way that doesn't break anything else.
 % 7/20/12  dhb      Undid 7/16/12 change.  Error was due to a stale IOPort on my path
+% 12/04/12 zlb      Adding PR-705 support.
 
 global g_serialPort g_useIOPort;
 
@@ -65,20 +67,10 @@ DefaultNumberOfTries = 5;
 
 % Read the local preferred serial port file if it exists.
 if exist(which('CMPreferredPort.txt'), 'file')
-	t = textread(which('CMPreferredPort.txt'), '%s');
-	defPortString = t{1};
+    t = textread(which('CMPreferredPort.txt'), '%s');
+    defPortString = t{1};
 else
-    if IsOSX
-        defPortString = 'usbserial';
-    end
-    
-    if IsLinux
-        defPortString = 'USB0';
-    end
-    
-    if IsWin
-        defPortString = 'COM5';
-    end
+    defPortString = '';
 end
 
 % Set default the defaults.
@@ -109,12 +101,11 @@ end
 % function in lieu of meterports=LoadCalFile.  I am not intrepid enough to
 % take that step.  -- MPR 11/21/07
 
-
 switch meterType
     case 1,
-        % PR-650
-        % Look for port information in "calibration" file.  If
-        % no special information present, then use defaults.
+    % PR-650
+    % Look for port information in "calibration" file.  If
+    % no special information present, then use defaults.
         meterports = LoadCalFile('PR650Ports');
         if isempty(meterports)
             if IsWin || IsOSX || IsLinux
@@ -125,7 +116,7 @@ switch meterType
         else
             portNameIn = meterports.in;
         end
-
+        
         if IsWin || IsOSX || IsLinux
             stat = PR650init(portNameIn);
             status = sscanf(stat,'%f');
@@ -134,7 +125,7 @@ switch meterType
                 disp('If colorimeter is off, turn it on; if it is on, turn it off and then on.');
             end
             NumTries = 0;
-
+            
             while (isempty(status) || status == -1) & NumTries < DefaultNumberOfTries %#ok<AND2>
                 stat = PR650init(portNameIn);
                 status = sscanf(stat,'%f');
@@ -167,7 +158,7 @@ switch meterType
             error(['Unsupported OS ' computer]);
         end
     case 2,
-        error('Support for CVI colormeter not yet implemented in PTB-3, sorry!');        
+        error('Support for CVI colormeter not yet implemented in PTB-3, sorry!');
     case 3,
         % CRS-Colorimeter:
         if exist('CRSColorInit') %#ok<EXIST>
@@ -175,10 +166,11 @@ switch meterType
         else
             error('CRSColorInit command is missing on your path. Is the CRS color calibration toolbox set up properly?');
         end
+        
     case 4,
-        % PR-655:
-        % Look for port information in "calibration" file.  If
-        % no special information present, then use defaults.
+    % PR-655:
+    % Look for port information in "calibration" file.  If
+    % no special information present, then use defaults.
         meterports = LoadCalFile('PR655Ports');
         if isempty(meterports)
             if IsWin || IsOSX || IsLinux
@@ -200,32 +192,53 @@ switch meterType
             end
         else
             error(['Unsupported OS ' computer]);
-		end
-		
-	% PR-670 - Functionality should be very similar to the PR-655, though
-	%          it looks like there are a few more commands available for
-	%          the 670.
-	case 5
-		if IsWin || IsOSX || IsLinux
-			% Look for port information in "calibration" file.  If
-			% no special information present, then use defaults.
-			meterports = LoadCalFile('PR670Ports');
-			if isempty(meterports)
-				portNameIn = FindSerialPort(PortString, g_useIOPort);
-			else
-				portNameIn = meterports.in;
-			end
-			
-			stat = PR670init(portNameIn);
-			if strcmp(stat, ' REMOTE MODE')
-				disp('Successfully connected to PR-670!');
-			else
-				disp('Failed to make contact.  If device is connected, try turning it off, type clear all, and then re-trying CMCheckInit.');
-			end
-		else
-			error(['Unsupported OS ' computer]);
-		end
-		
+        end
+        
+    % PR-670 - Functionality should be very similar to the PR-655, though
+    %          it looks like there are a few more commands available for
+    %          the 670.
+    case 5
+        if IsWin || IsOSX || IsLinux
+            % Look for port information in "calibration" file.  If
+            % no special information present, then use defaults.
+            meterports = LoadCalFile('PR670Ports');
+            if isempty(meterports)
+                portNameIn = FindSerialPort(PortString, g_useIOPort);
+            else
+                portNameIn = meterports.in;
+            end
+            
+            stat = PR670init(portNameIn);
+            if strcmp(stat, ' REMOTE MODE')
+                disp('Successfully connected to PR-670!');
+            else
+                disp('Failed to make contact.  If device is connected, try turning it off, type clear all, and then re-trying CMCheckInit.');
+            end
+        else
+            error(['Unsupported OS ' computer]);
+        end
+        
+        
+    % PR-705
+    case 6,
+        if IsWin || IsOSX || IsLinux
+            meterports = LoadCalFile('PR705Ports');
+            if isempty(meterports)
+                portNameIn = FindSerialPort(PortString, g_useIOPort);
+            else
+                portNameIn = meterports.in;
+            end
+            
+            stat = PR705init(portNameIn);
+            if strcmp(stat, [' REMOTE MODE' 13 10])
+                disp('Successfully connected to the PR-705!');
+            else
+                disp('Failed to make contact.  If device is connected, try turning it off, type clear all, and then re-trying CMCheckInit.');
+            end
+        else
+            error(['Unsupported OS ' computer]);
+        end
+        
     otherwise,
         error('Unknown meter type');
 end

--- a/Psychtoolbox/PsychHardware/CMClose.m
+++ b/Psychtoolbox/PsychHardware/CMClose.m
@@ -8,12 +8,14 @@ function CMClose(meterType)
 % meterType 3 is the CRS Colorimeter
 % meterType 4 is the PR655
 % meterType 5 is the PR670
+% meterType 6 is the PR705
 %
 % 2/15/02  dhb  Wrote it.
 % 4/13/02  dgp	Cosmetic.
 % 2/26/03  dhb  Added more meter types. 
 % 3/27/03  dhb, jmh  Fix up default argument.
 % 2/07/09  mk, tbc  Add PR-655 support.
+% 12/04/12 zlb  Add PR-705 support.
 
 % Set default meterType.
 if nargin < 1 || isempty(meterType)
@@ -37,6 +39,9 @@ switch meterType
     case 5
 		% PR-670
         PR670close;
+    case 6
+        % PR-705
+        PR705close;
 	otherwise,
 		error('Unknown meter type');
 end

--- a/Psychtoolbox/PsychHardware/MeasSpd.m
+++ b/Psychtoolbox/PsychHardware/MeasSpd.m
@@ -3,16 +3,17 @@ function [spectrum,qual] = MeasSpd(S,meterType,syncMode)
 %
 % This routine splines the raw return values from the
 % meter to the wavelength sampling S.  The splining
-% handles conversion of power units according to 
+% handles conversion of power units according to
 % to the wavelength sampling delta.  If S is not passed,
 % it is set to [380 5 81].
 %
 % Tries to handle low light level case gracefully by returning
-% zero as the answer. 
+% zero as the answer.
 %
 % meterType == 1:  PR650 (default)
 % meterType == 4:  PR655
 % meterType == 5:  PR670
+% meterType == 6:  PR705
 %
 % syncMode = 'on':  Try to sync integration time with display, if meter supports it (default)
 % syncMode = 'off': Don't try to sync, even if meter supports it.
@@ -38,6 +39,7 @@ function [spectrum,qual] = MeasSpd(S,meterType,syncMode)
 % 2/26/03       dhb   Change definition of PR-650 meter type to 1.
 % 8/26/10       dhb   The PR-655 line called the PR-650 code.  Change to call PR-655
 % 3/8/11        dhb   Pass syncMode option to speed things up for displays where it doesn't work.
+% 12/06/12      zlb   Adding PR-705 support as meter type 6.
 
 % Handle defaults
 if nargin < 3 || isempty(syncMode)
@@ -50,19 +52,30 @@ if nargin < 1 || isempty(S)
     S = [380 5 81];
 end
 
-switch meterType
-    % PR-650
-    case 1,
-        [spectrum, qual] = PR650measspd(S,syncMode);
-        
-    % PR-655
-    case 4,
-        [spectrum, qual] = PR655measspd(S,syncMode);
-        
-    % PR-670
-    case 5,
-        [spectrum, qual] = PR670measspd(S,syncMode);
-        
-    otherwise,
-        error('Unknown meter type');
+try
+    switch meterType
+        % PR-650
+        case 1,
+            [spectrum, qual] = PR650measspd(S,syncMode);
+            
+        % PR-655
+        case 4,
+            [spectrum, qual] = PR655measspd(S,syncMode);
+            
+        % PR-670
+        case 5,
+            [spectrum, qual] = PR670measspd(S,syncMode);
+            
+        % PR-705
+        case 6,
+            qual = 0;
+            spectrum = PR705measspd(S);
+            
+        otherwise,
+            error('Unknown meter type');
+    end
+catch %#ok<CTCH>
+    CMClose(meterType);
+    sca();
+    psychrethrow(psychlasterror);
 end

--- a/Psychtoolbox/PsychHardware/PR705Toolbox/PR705close.m
+++ b/Psychtoolbox/PsychHardware/PR705Toolbox/PR705close.m
@@ -1,0 +1,21 @@
+function PR705close()
+% PR705close - Closes the PR-705 connection.
+%
+% Syntax:
+% PR705close
+%
+% Description:
+% Exits PR-705 remote mode, then closes the serial port connection.
+%
+% 11/29/12    zlb   Wrote it based on the PR670Toolbox.
+
+global g_serialPort
+
+% Close and clear serial port, if it is open.
+% Also take the device out of remote mode.
+if ~isempty(g_serialPort)
+    IOPort('Purge', g_serialPort);
+    PR705write('Q');
+    IOPort('Close', g_serialPort);
+    g_serialPort = [];
+end

--- a/Psychtoolbox/PsychHardware/PR705Toolbox/PR705config.m
+++ b/Psychtoolbox/PsychHardware/PR705Toolbox/PR705config.m
@@ -1,0 +1,88 @@
+function out = PR705config(varargin)
+% PR705config - Update the PR-705 configuration.
+%
+% Syntax:
+% config_str (string) = PR705config
+% errcode (scalar) = PR705config('Option1', value1, 'Option2', value2, ...)
+%
+% Description:
+% A wrapper for setting various options on the PR-705 using the 'S'
+% command. With no input arguments, the function merely returns the device's
+% current configuration string. In the multiple input arguments case, here
+% are the case-insensitive options and the values they take:
+% Lens         ID Number of PRIMARY accessory
+% Add1         ID Number of 1st ADD ON accessory
+% Add2         ID Number of 2nd ADD ON accessory
+% Aperture     ID Number of Aperture
+% Units        0 for English
+%              1 for Metric
+% ExposureTime 0 - Adaptive
+%              25 ... 60000 ms
+% CaptureMode  0 - Single Capture
+%              1 - Continuous Capture
+% Cycles       1 .. 99 - Number of Captures to average
+% CalcMode     0 - Power
+%              1 - Energy
+% TriggerMode  0 - Manual
+%              1 - External
+% ViewShutter  0 - Open During Measurement
+%              1 - Closed During Measurement
+% CIEObserver  0 -  2 Degree
+%              1 - 10 Degree
+%
+% Example:
+% errcode = PR705config('Lens', 0, 'Units', 1, 'Cycles', 2, 'ViewShutter', 1);
+%
+% 12/06/12    zlb   Wrote it.
+
+global g_serialPort
+
+if ~nargin
+    IOPort('Purge', g_serialPort);
+    PR705write('D601');
+    out = PR705read(1, 100);
+    return
+end
+
+values = validate_sort_input(varargin);
+
+setup_str = 'S%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d';
+setup_str = sprintf(setup_str, values{:});
+
+if length(setup_str) > 12 % i.e., 'values' had at least 1 non-empty element
+    IOPort('Purge', g_serialPort);
+    PR705write(setup_str);
+    errcode = PR705read(1, 10);
+    out = sscanf(errcode, '%d');
+else % a noop is trivially successful
+    out = 0;
+end
+
+function sorted_values = validate_sort_input(raw_input)
+valid_sorted_options = {'Lens' 'Add1' 'Add2' 'Aperture' 'Units' 'ExposureTime' ...
+    'CaptureMode' 'Cycles' 'CalcMode' 'TriggerMode' 'ViewShutter' 'CIEObserver'};
+
+sorted_values = cell(size(valid_sorted_options));
+if mod(numel(raw_input), 2)
+    fprintf('Expecting an even number of arguments (option-value pairs)!\n');
+    return
+end
+
+options = raw_input(1:2:end);
+values = raw_input(2:2:end);
+if ~all(cellfun(@ischar, options)) || ~all(cellfun(@isscalar, values))
+    fprintf('Improper formatting of the option-value pairs!\n');
+    return
+end
+
+[valid_members,location] = ismember(lower(options), lower(valid_sorted_options));
+if ~all(valid_members)
+    invalid_options = options(~valid_members);
+    fprintf('The following options aren''t recognized and will be ignored:\n');
+    fprintf('\t%s\n', invalid_options{:});
+end
+
+values = values(valid_members);
+location = location(valid_members);
+
+sorted_values(location) = values(:);

--- a/Psychtoolbox/PsychHardware/PR705Toolbox/PR705init.m
+++ b/Psychtoolbox/PsychHardware/PR705Toolbox/PR705init.m
@@ -1,0 +1,37 @@
+function response = PR705init(portString)
+% PR705init - Initialize the serial port to talk to the PR-705.
+%
+% Syntax:
+% retval = PR705init
+% retval = PR705init(portString)
+%
+% Description:
+% Initializes the serial port and establishes remote mode for the PR-705.
+%
+% Input:
+% portString (1xN char) - Name of the serial port to use.
+%
+% Output:
+% response (1xN char) - Character data returned from the PR-705.
+%
+% 11/29/12    zlb   Wrote it based on the PR670Toolbox. 
+
+global g_serialPort g_useIOPort
+
+if nargin == 0
+    % Let FindSerialPort do its job
+    portString = FindSerialPort('', g_useIOPort);
+end
+
+% Only open if we haven't already.
+if isempty(g_serialPort)
+    % IOPort has above port settings 9600 baud, no parity, 8 data bits,
+    % 1 stopbit, no handshake (aka FlowControl=none) already as
+    % built-in defaults, so no need to pass them:
+    oldverbo = IOPort('Verbosity', 2);
+    g_serialPort = IOPort('OpenSerialPort', portString);
+    IOPort('Verbosity', oldverbo);
+end
+
+PR705write('PR705');
+response = PR705read(1, 16); % get the ' REMOTE MODE' response

--- a/Psychtoolbox/PsychHardware/PR705Toolbox/PR705measspd.m
+++ b/Psychtoolbox/PsychHardware/PR705Toolbox/PR705measspd.m
@@ -1,0 +1,41 @@
+function spd = PR705measspd(S)
+% PR705measspd - Get a spectral power distribution from the PR-705.
+%
+% Syntax:
+% spd = PR705measspd([S])
+%
+% Input:
+% S (1x3) - Desired wavelength sampling. Default: [380 5 81]
+%
+% Output:
+% spd (Nx1) - The spectral power distribution (N = S(3) or 81 by default).
+%
+% 12/06/12   zlb   Wrote it loosely based on the PR670Toolbox.
+
+% PR-705 measurement error codes
+%   -5000: Weak Signal
+%   -4999: Time underflow, level overflow
+%   -4996: A2D overflow, measuring light
+%   -4995: A2D overflow, measuring dark
+%   -4994: Variable light level
+%   -4993: Adaptive exposure time limit
+
+if nargin < 1 || isempty(S)
+    S = [380 5 81];
+end
+
+timeout = 300;
+[rawspd,errcode] = PR705rawspd(timeout);
+
+if isempty(rawspd) || isempty(errcode)
+    error('Didn''t get a measurement reponse after %d seconds', timeout);
+end
+
+switch errcode
+    case 0
+        spd = PR705parsespdstr(rawspd, S);
+    case {-4995,-4993} % too dark?
+        spd = zeros(S(3), 1);
+    otherwise
+        error('Received unhandled error code %d', errcode);
+end

--- a/Psychtoolbox/PsychHardware/PR705Toolbox/PR705parsespdstr.m
+++ b/Psychtoolbox/PsychHardware/PR705Toolbox/PR705parsespdstr.m
@@ -1,0 +1,45 @@
+function spd = PR705parsespdstr(rawspd, S)
+% PR705parsespdstr - Parses the spectral power distribution string returned by the PR-705.
+%
+% Syntax:
+% spd = PR705parsespdstr(rawspd [, S])
+%
+% Description:
+% Parse the spectral power distribution string returned by the PR-705. The
+% results are splined to the desired wavelength sampling defined by the 'S'
+% input parameter.
+%
+% Input:
+% rawspd (1xN char) - Raw data returned from a meter measurment.
+% S (1x3) - Wavelength sampling.  Default: [380 5 81]
+%
+% 12/06/12    zlb   Wrote it based on the PR670Toolbox.
+
+if nargin < 2 || isempty(S)
+    S = [380 5 81];
+end
+
+spd = [];
+if ~isempty(rawspd)
+    C = textscan(rawspd, '%d,%f', 'HeaderLines', 1);
+    wls = C{1}; spd = C{2};
+    
+    if isempty(wls) || isempty(spd)
+        return
+    end
+    
+    if numel(wls) ~= 201 % 201 is the PR-705 default
+        error('Unexpected number of wavelength samples for PR-705!');
+    elseif wls(2) - wls(1) ~= 2 || ~all(diff(wls) == 2)
+        error('Unexpected wavelength sampling for the PR-705!');
+    end
+    
+    % We _don't_ multiply the amplitudes by the bin spacing (2 nm in this 
+    % case) because the data given by the meter are in units, not units/nm,
+    % as per the documentation.
+    
+    if S(3) ~= 201
+        S0 = [wls(1) wls(2)-wls(1) length(wls)];
+        spd = SplineSpd(S0, spd, S);
+    end
+end

--- a/Psychtoolbox/PsychHardware/PR705Toolbox/PR705rawspd.m
+++ b/Psychtoolbox/PsychHardware/PR705Toolbox/PR705rawspd.m
@@ -1,0 +1,33 @@
+function [rawspd,errcode] = PR705rawspd(timeout)
+% PR705rawspd - Takes an spd measurement and returns the results.
+%
+% Syntax:
+% rawspd = PR705rawspd(timeout)
+%
+% Input:
+% timeout (scalar) - Timeout period in seconds.
+%
+% Output:
+% rawspd (1xN char) - The raw character array resulting from a measurement.
+% This will be an empty string if the timeout period was reached.
+% errcode (scalar) - The error code reported by the meter (success = 0).
+%
+% 12/06/12   zlb   Wrote it.
+
+global g_serialPort
+
+if nargin < 1 || isempty(timeout)
+    timeout = 300;
+end
+
+IOPort('Purge', g_serialPort);
+PR705write('M5');
+
+WaitSecs(0.5);
+max_wait_time = GetSecs() + timeout;
+while GetSecs() < max_wait_time && ~IOPort('BytesAvailable', g_serialPort)
+    WaitSecs(0.5);
+end
+
+rawspd = PR705read();
+errcode = sscanf(rawspd, '%d');

--- a/Psychtoolbox/PsychHardware/PR705Toolbox/PR705read.m
+++ b/Psychtoolbox/PsychHardware/PR705Toolbox/PR705read.m
@@ -1,0 +1,39 @@
+function varargout = PR705read(varargin)
+% PR705read - Read data from the PR-705.
+%
+% Syntax:
+% serialData = PR705read([block=0] [, nbytes])
+%
+% Description:
+% This is a convenience wrapper to read data from the PR-705 device. Aside
+% from not requiring an explicit port handle, this function is identical to
+% IOPort's Read (see IOPort Read? for more details).
+%
+% Output:
+% serialData (1xN char).
+%
+% 11/29/12    zlb   Wrote it based on the PR670Toolbox.
+
+global g_serialPort
+
+if isempty(g_serialPort)
+    error('Meter has not been initialized.');
+end
+
+if nargin > 2 || nargout > 3
+    error('Invalid input/output arguments. Please refer to ''help PR750read''.\n');
+end
+
+[varargout{1:nargout}] = IOPort('Read', g_serialPort, varargin{:});
+
+if ~isempty(varargout{1}) && (~nargin || varargin{1} == 0)
+    % If data exists keep reading off the port until there's nothing left.
+    while true
+        WaitSecs(0.05);
+        [tmpData varargout{2:nargout}] = IOPort('Read', g_serialPort);
+        if isempty(tmpData), break; end
+        varargout{1} = [varargout{1} tmpData];
+    end
+end
+
+varargout{1} = char(varargout{1});

--- a/Psychtoolbox/PsychHardware/PR705Toolbox/PR705write.m
+++ b/Psychtoolbox/PsychHardware/PR705Toolbox/PR705write.m
@@ -1,0 +1,33 @@
+function varargout = PR705write(datastr, varargin)
+% PR705write - Write a string of characters to the PR-705.
+%
+% Syntax:
+% varargout = PR705write(cmdStr [, block=1])
+%
+% Description:
+% This is a convenience wrapper to write data to the PR-705 device. Aside
+% from appending a carriage return and not requiring an explicit port
+% handle, this function is identical to IOPort's Write (see IOPort Write? 
+% for more details).
+%
+% Inputs:
+% datastr (1xN char) - data string to write to the PR-705.
+% block (scalar) - enable (1, default) or disable (0) blocking writes
+%
+% Outputs:
+% Refer to IOPort Write?
+%
+% 11/29/12    zlb   Wrote it.
+
+global g_serialPort
+
+if nargin < 1 || isempty(datastr) || nargin > 2 || nargout > 6
+    error('Invalid input/output arguments. Please refer to ''help PR750write''.\n');
+end
+
+if datastr(end) ~= 13 && ~strcmp(datastr, 'PR705') % only command that doesn't require a CR
+    datastr = [datastr 13];
+end
+
+% Write sequence of chars to PR-705.
+[varargout{1:nargout}] = IOPort('Write', g_serialPort, upper(datastr), varargin{:});


### PR DESCRIPTION
1. PR-705 toolbox
   - Follows a similar format to the other toolboxes
     - Open and close remote communication
     - Read and write data
     - Take spectral measurements
     - Change the meter's configuration

Note: the monitor calibration scripts haven't been updated to use the PR-705 (yet).
