### PR TITLE
Fixing a redundancy when using a Keyspan USB-serial adapter

### DIFF
--- a/Psychtoolbox/PsychHardware/FindSerialPort.m
+++ b/Psychtoolbox/PsychHardware/FindSerialPort.m
@@ -41,6 +41,8 @@ function PortNumber = FindSerialPort(PortString, forIOPort, dontFail)
 %                           minimal modifications) from sample code donated
 %                           by Xiangrui Li. Thanks!
 %           6/14/09   mk    Remove redundant special case code for Octave.
+%          12/04/12   zlb   Removed usa19* from PortDB since Keyserial1 is
+%                           an alias for the first port anyway.
 
 % Comments from mpr:
 %
@@ -71,7 +73,7 @@ function PortNumber = FindSerialPort(PortString, forIOPort, dontFail)
 if ~nargin || isempty(PortString)	
 	% List of serial port devices to look for. These should all be lower case:
     if IsOSX
-        PortDB = { lower('usa19'), lower('keyserial1'), lower('usbmodem'), lower('usbserial') };
+        PortDB = { lower('keyserial1'), lower('usbmodem'), lower('usbserial') };
     end
     
     if IsLinux


### PR DESCRIPTION
Keyserial1 is an alias to the first port on your Keyspan adapter
(regardless if it's single- or multi-port). USA19\* is a prefix to the
raw port on a single-port adapter. Therefore it's redundant to have
both in PortDB. In fact it's an error when FindSerialPort finds > 1
match by default.
