### PR TITLE
Parse the java classpaths with a newline delimiter

### DIFF
--- a/Psychtoolbox/PsychtoolboxPostInstallRoutine.m
+++ b/Psychtoolbox/PsychtoolboxPostInstallRoutine.m
@@ -559,8 +559,10 @@ if ~IsOctave
                 % doesn't already exist:
                 prefFolder = prefdir(1);
                 classpathFile = [prefFolder filesep 'javaclasspath.txt'];
-                fid = fopen(classpathFile, 'w');
-                fclose(fid);
+                if ~exist(classpathFile, 'file')
+                    fid = fopen(classpathFile, 'w');
+                    fclose(fid);
+                end
             end
         end
         


### PR DESCRIPTION
Seems Mathworks started adding comments (tested on R2013a) to the classpath.txt file of the form `# comments with spaces`. When PsychtoolboxPostInstallRoutine adds PsychJava to the classpath, it `textscan`s the input which by default breaks on whitespace. This results in an output that has newlines injected where ever there was whitespace originally.
