### PR TITLE
USB-1208FS excessive memory usage fix

### DIFF
--- a/Psychtoolbox/PsychHardware/Daq/DaqAInScan.m
+++ b/Psychtoolbox/PsychHardware/Daq/DaqAInScan.m
@@ -856,8 +856,10 @@ if options.end || (isfield(options, 'livedata') && options.livedata)
         SE_Channels = find(channel > 7);
         
         data(:,DiffChannels) = bitshift(data(:,DiffChannels),-4);
-        [NegativeDiffs,DCs] = find(data(:,DiffChannels) > 2048);
-        data(NegativeDiffs,DiffChannels(DCs)) = -bitcmp(data(NegativeDiffs,DiffChannels(DCs)),12)-1;
+        
+		ix = data(:,DiffChannels) > 2048;
+        data(ix) = -bitcmp(data(ix),12)-1;
+		
         SE_Data = data(:,SE_Channels);
         
         OverflowInds = find(SE_Data > 32752);


### PR DESCRIPTION
So when using the PsychToolbox with my 1208FS I noticed for large sampling rates and lengths of time that it crashed my computer and was consuming excessive amounts of RAM. It boiled down to the way that the find() output was being used, which was transforming the matrix from a N x Channels to a NxN matrix (depending on how many values were above 2048). I changed the way the indexing works and it seems to work well for me, no more crashes, much faster and little memory. I can get my sampling upto ~45kHz now easily. This was on Windows 8 x64 Matlab 2012.
