### PR TITLE
Add option to disable feedback beep

### DIFF
--- a/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkBasic/EyelinkInitDefaults.m
+++ b/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkBasic/EyelinkInitDefaults.m
@@ -77,6 +77,7 @@ el.targetdisplaysound='EyelinkTargetBeep';
 el.calibrationfailedsound='EyelinkErrorBeep';
 el.calibrationsuccesssound='EyelinkSuccessBeep';
 el.targetbeep=1;  % sound a beep when a target is presented
+el.feedbackbeep=1;  % sound a beep after calibration/drift correction
 
 % define beep sounds (frequency, volume, duration);
 el.cal_target_beep=[1250 0.6 0.05];

--- a/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkBasic/PsychEyelinkDispatchCallback.m
+++ b/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkBasic/PsychEyelinkDispatchCallback.m
@@ -442,28 +442,33 @@ switch(s)
         v=el.drift_correction_target_beep(2);
         d=el.drift_correction_target_beep(3);
     case 'calibration_failed_beep'
-        doBeep=1;
+%         doBeep=1;
+        doBeep=el.feedbackbeep;
         f=el.calibration_failed_beep(1);
         v=el.calibration_failed_beep(2);
         d=el.calibration_failed_beep(3);
     case 'calibration_success_beep'
-        doBeep=1;
+%         doBeep=1;
+        doBeep=el.feedbackbeep;
         f=el.calibration_success_beep(1);
         v=el.calibration_success_beep(2);
         d=el.calibration_success_beep(3);
     case 'drift_correction_failed_beep'
-        doBeep=1;
+%         doBeep=1;
+        doBeep=el.feedbackbeep;
         f=el.drift_correction_failed_beep(1);
         v=el.drift_correction_failed_beep(2);
         d=el.drift_correction_failed_beep(3);
     case 'drift_correction_success_beep'
-        doBeep=1;
+%         doBeep=1;
+        doBeep=el.feedbackbeep;
         f=el.drift_correction_success_beep(1);
         v=el.drift_correction_success_beep(2);
         d=el.drift_correction_success_beep(3);
     otherwise
         % some defaults
-        doBeep=1;
+%         doBeep=1;
+        doBeep=el.feedbackbeep;
         f=500;
         v=0.5;
         d=1.5;


### PR DESCRIPTION
Beeper and Snd functions used in Eyelink toolbox now depend on PsychPortAudio. This might interfere with auditory experiments. Option to disable the feedback beep (additionally to the already existing option for targetbeep) would be appreciated.
