### PR TITLE
Disable hardcoded setting of heuristic filter in old code path

### DIFF
--- a/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkBasic/EyelinkDoTrackerSetup.m
+++ b/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkBasic/EyelinkDoTrackerSetup.m
@@ -41,7 +41,7 @@ end
 % else we continue with the old version
 
 
-Eyelink('Command', 'heuristic_filter = ON');
+% Eyelink('Command', 'heuristic_filter = ON');
 Eyelink( 'StartSetup' );		% start setup mode
 Eyelink( 'WaitForModeReady', el.waitformodereadytime );  % time for mode change
 


### PR DESCRIPTION
The setting of the Eyelink heuristic filter in the old code path (which we still use for animated calibration targets) DoTrackerSetup is completely unexpected, undocumented and inconsistent with the new code path. Manual settings in the Eyelink interface are possibly overwritten. The patch disables the setting of the heuristic filter. Alternatively the setting should be made explicit and documented and consistently applied to new and old codepath.
