### PR TITLE
Search and destroy evil codepage trash 

### DIFF
--- a/Psychtoolbox/PsychCal/UpdateAmbient.m
+++ b/Psychtoolbox/PsychCal/UpdateAmbient.m
@@ -16,7 +16,7 @@ function cal = UpdateAmbient(cal,newP_ambient,ADD)
 % linear color space defined by the call to SetColorSpace.  To
 % do this, use UpdateAmbientLinear.
 %
-%ÊIf flag ADD is true, passed ambient is added to current
+% If flag ADD is true, passed ambient is added to current
 % value.  Otherwise passed value replaces current value.
 % ADD is false if not passed.  Use caution when setting ADD
 % true -- if the ambient is changing during the experiment

--- a/Psychtoolbox/PsychCal/UpdateAmbientSensor.m
+++ b/Psychtoolbox/PsychCal/UpdateAmbientSensor.m
@@ -6,7 +6,7 @@ function cal = UpdateAmbientSensor(cal,new_ambient_sensor,ADD)
 % same units as defined by T_sensor in the call to
 % SetColorSpace.
 %
-%ÊIf flag ADD is true, passed ambient is added to current
+% If flag ADD is true, passed ambient is added to current
 % value.  Otherwise passed value replaces current value.
 % ADD is false if not passed.  Use caution when setting ADD
 % true -- if the ambient is changing during the experiment

--- a/Psychtoolbox/PsychColorimetric/PsychMunsell/MunsellConversionTest.m
+++ b/Psychtoolbox/PsychColorimetric/PsychMunsell/MunsellConversionTest.m
@@ -24,7 +24,7 @@ munsellData = MunsellPreprocessTable;
 
 % Enter in some test values with known answers from other sources.
 % The comparison source is a Munsell conversion program that Inji found on 
-% the web.  The program output was used directly to get the xyY values
+% the web.  The program output was used directly to get the xyY values
 % for the inputs below, except for the first one in the list.
 %
 % For the first one in the list, the conversion program gives the wrong luminance,

--- a/Psychtoolbox/PsychColorimetric/PsychMunsell/MunsellPreprocessTable.m
+++ b/Psychtoolbox/PsychColorimetric/PsychMunsell/MunsellPreprocessTable.m
@@ -1,7 +1,7 @@
 function munsellData = MunsellPreprocessTable
 % munsellData = MunsellPreprocessTable
 % 
-% Load in Munsell renotation table from RIT site and convert it to the form where we will
+% Load in Munsell renotation table from RIT site and convert it to the form where we will
 % actually use it.
 %
 % See http://www.cis.rit.edu/mcsl/online/munsell.php to download the data file.  Our version

--- a/Psychtoolbox/PsychColorimetricData/DefaultPhotoreceptors.m
+++ b/Psychtoolbox/PsychColorimetricData/DefaultPhotoreceptors.m
@@ -134,7 +134,7 @@ switch (kind)
    % The Melanopic Sensitivity Function Accounts for Melanopsin-Driven Responses in Mice under
    % Diverse Lighting Conditions. PLoS One, 8(1), e53583. doi: 10.1371/journal.pone.0053583.
    %
-   % Viénot, F., Brettel, H., Dang, T.V., Le Rohellec, J. (2012). Domain of metamers exciting
+   % Vienot, F., Brettel, H., Dang, T.V., Le Rohellec, J. (2012). Domain of metamers exciting
    % intrinsically photosensitive retinal ganglion cells (ipRGCs) and rods. J Opt Soc Am A Opt
    % Image Sci Vis. 29(2): A366-76. doi: 10.1364/JOSAA.29.00A366.
     case 'LivingHumanMelanopsin'

--- a/Psychtoolbox/PsychDemos/PsychExampleExperiments/MullerLyerIllusion.m
+++ b/Psychtoolbox/PsychDemos/PsychExampleExperiments/MullerLyerIllusion.m
@@ -43,7 +43,7 @@ function results = MullerLyerIllusion(subID)
 % Exemplary reference:
 %
 %   Restle F & Decker J (1977) Size of the Mueller-Lyer illusion as a
-%   function of its dimensions: Theory and data. Perception & Psychophysics 21:489–503
+%   function of its dimensions: Theory and data. Perception & Psychophysics 21:489 503
 %
 % History:
 % 3/3/2008  Included in Psychtoolbox (MK).

--- a/Psychtoolbox/PsychFiles/PsychSaveAsEps.m
+++ b/Psychtoolbox/PsychFiles/PsychSaveAsEps.m
@@ -1,7 +1,7 @@
 function SaveAsEps(filename,m,pageRect,resolution)
 % SaveAsEps(filename,m,[pageRect],[resolution]);
 % Based on WindowToEps.c of the VideoToolbox.
-% Copyright © 1996-2003 Denis G. Pelli
+% Copyright (c) 1996-2003 Denis G. Pelli
 % 
 % SaveAsEps converts a grayscale image (in a Matlab matrix) to a
 % PostScript file that a LaserWriter or Linotype will accurately render on
@@ -13,9 +13,9 @@ function SaveAsEps(filename,m,pageRect,resolution)
 % "creator" of the eps file is set to Microsoft Word, so double-clicking
 % it will open it as a Word document containg the image.
 % 
-% I suggest you use the $25 shareware Macintosh application EPS¥Factory 
+% I suggest you use the $25 shareware Macintosh application EPS Factory 
 % to add a PICT preview to your file, based on the postscript already 
-% there. You can download EPS¥Factory from 
+% there. You can download EPS Factory from 
 % web http://www.artage.com/pages/products/products.html
 % (The old freeware ps2eps is incompatible with Mac OS 8.6 and 9, alas.)
 % The PICT preview will make the image will look approximately right on 
@@ -157,7 +157,7 @@ function SaveAsEps(filename,m,pageRect,resolution)
 % 9/7/98 dgp	convert image (which might be uint8) to double.
 % 3/17/99 dgp	mention ps2eps.
 % 1/23/00 dgp	ps2eps is incompatible with Mac OS 8.6 and 9; recommend
-% 				EPS¥Factory instead.
+% 				EPS Factory instead.
 
 if nargin<2
 	error('Usage: SaveAsEps(filename,m,[pageRect,resolution])');

--- a/Psychtoolbox/PsychGamma/MonitorGammaError.m
+++ b/Psychtoolbox/PsychGamma/MonitorGammaError.m
@@ -1,8 +1,8 @@
 function err=MonitorGammaError(p,x,y)
 % err=MonitorGammaError(p,x,y)
 % Returns mean squared error of fit of y data by MonitorGamma function of x. The
-% MonitorGamma parameters are x0=p(1) and gamma=p(2). We constrain 0²x0²1 and
-% gamma³0, and augment the error when they are out of bounds, so that minimization
+% MonitorGamma parameters are x0=p(1) and gamma=p(2). We constrain 0^2 x 0^2 1 and
+% gamma^3 0, and augment the error when they are out of bounds, so that minimization
 % will always settle on in-bound values.
 %
 % Denis Pelli 5/26/96

--- a/Psychtoolbox/PsychHardware/BitsPlusToolbox/BitsPlusTests/BitsPlusMovieFrameTest.m
+++ b/Psychtoolbox/PsychHardware/BitsPlusToolbox/BitsPlusTests/BitsPlusMovieFrameTest.m
@@ -13,7 +13,7 @@
 % 9/20/02  dhb  Version created from ClutMovieDemo.
 % 10/xx/02 jmh  Fixed it up.
 % 11/4/02  dhb, jmh Comments, etc.
-% 11/6/02  jmh  Modified BitsPlusMovieDemo to test for lost frames
+% 11/6/02  jmh  Modified BitsPlusMovieDemo to test for lost frames
 
 clear all; close all
 

--- a/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkDemos/notOSXed/Palmerdemo_notOSXed/SimpleStepExperiment.m
+++ b/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkDemos/notOSXed/Palmerdemo_notOSXed/SimpleStepExperiment.m
@@ -51,7 +51,7 @@ h.initialseed = ClockRandSeed;			% set seed w/ clock and put in header
 h.distance = '60 cm';					% distance from eye to ctr of screen
 hres = 832; vres = 624; tres = 75;		% define screen resolution
 h.screenresolution = ...
-	strcat(num2str(hres),' by ',num2str(vres),' pixels at ',num2str(tres),' Hz');
+	strcat(num2str(hres),' by:',num2str(vres),' pixels at:',num2str(tres),' Hz');
 h.screensize = '35 by 25.5 cm';
 h.pixelsperdegree = 25.5;				% based on central 1 degree region
 pausekey = 'space';						% key to pause experiment

--- a/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkTests/testbutton.m
+++ b/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkTests/testbutton.m
@@ -15,7 +15,7 @@ function testbutton
 % Typical Results:
 % getsecs overhead 0.02 ms
 % EXGetEyeLink overhead 0.60 ms
-% random error in eyelink time ~ ±0.50 ms, good for a ms clock!
+% random error in eyelink time ~ +-0.50 ms, good for a ms clock!
 
 fprintf('TestButton:  hold down key on keyboard and press button to exit\n');
 if eyelink('initialize') 				% initialize eyelink

--- a/Psychtoolbox/PsychHardware/EyelinkToolbox/contents.m
+++ b/Psychtoolbox/PsychHardware/EyelinkToolbox/contents.m
@@ -1,7 +1,7 @@
 % 	EyelinkToolbox.
 % 
 % 	The EyelinkToolbox can be used to ceate eye-movement experiments and
-%   control the SR-Research Eyelink© gazetrackers
+%   control the SR-Research Eyelink(c) gazetrackers
 %   (http://www.eyelinkinfo.com/) from within Matlab and Octave.
 %   It is incorporated into the PsychToolbox (http://www.psychtoolbox.org/).
 %   It provides an interface to the Eyelink Gazetracker.

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/Obsolete/testiviewxcomm.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/Obsolete/testiviewxcomm.m
@@ -80,7 +80,7 @@ try
             end
         end
         % If you want the subject to manually accept the point with a
-        % key press once they fixate, the ÒET_ACCÓ  command must then
+        % key press once they fixate, the "ET_ACC"  command must then
         % be sent to the serial port.  This instructs iView to change
         % to the next calibration point  rather than having it detect
         % fixations itself.

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/iViewXCalibrate.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/iViewXCalibrate.m
@@ -99,7 +99,7 @@ try
         nPointsShown=nPointsShown+1;
         nextPt=0;
         %     After displaying the first point, the software must monitor
-        %     the serial port for further ÒET_CHGÓ commands or  ÒET_BRKÓ,
+        %     the serial port for further "ET_CHG" commands or  "ET_BRK",
         %     which cancels the calibration procedure.
         % we also detect manual acceptance of calibration point
         while nextPt==0
@@ -126,7 +126,7 @@ try
             end
 
             % If you want the subject to manually accept the point with a
-            % key press once they fixate, the ÒET_ACCÓ  command must then
+            % key press once they fixate, the "ET_ACC"  command must then
             % be sent to the serial port.  This instructs iView to change
             % to the next calibration point  rather than having it detect
             % fixations itself.

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/Contents.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/Contents.m
@@ -1,10 +1,10 @@
 %TCP_UDP_IP  - Network comunication with other applic. & remote matlab control.
 %
 % This is version 2.x of the tcp/udp/ip Toolbox by
-% Peter Rydesäter with support from  Mario Bergeron,  Mike Medeiros
+% Peter Rydesaeter with support from  Mario Bergeron,  Mike Medeiros
 % Se the pnet.c file for more information.
 %
-% (C) 1998-2002 Peter Rydesäter, Mitthögskolan Östersund
+% (C) 1998-2002 Peter Rydesaeter, Mitthoegskolan Oestersund
 %     GNU Public License, Se pnet.c for more license information.
 %
 % Contents.m            This help file.

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/pnet.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/pnet.m
@@ -227,8 +227,8 @@
 %
 %   GOOD LUCK and HAVE FUN!  :-)
 %
-%       Peter Rydesäter, 
-%       Mitthögskolan(Mid Sweden University) campus Östersund, SWEDEN
+%       Peter Rydesaeter, 
+%       Mitthoegskolan(Mid Sweden University) campus Oestersund, SWEDEN
 %
 
 error('You need to compile pnet.c to a mex-file for your platform. Read the header of pnet.c');

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/pnet_getvar.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/pnet_getvar.m
@@ -15,7 +15,7 @@ function varargout=pnet_getvar(fid)
 
 
 %
-%   This file(s) is part of the tcp_udp_ip toolbox (C) Peter Rydesäter et al.  
+%   This file(s) is part of the tcp_udp_ip toolbox (C) Peter Rydesaeter et al.  
 %   et al.  1998-2003 for running in MATLAB(R) as scripts and/or plug-ins.
 %
 %   This program is free software; you can redistribute it and/or modify
@@ -32,7 +32,7 @@ function varargout=pnet_getvar(fid)
 %   along with this program; if not, write to the Free Software
 %   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 %
-%   In addition, as a SPECIAL EXCEPTION, Peter Rydesäter, SWEDEN,
+%   In addition, as a SPECIAL EXCEPTION, Peter Rydesaeter, SWEDEN,
 %   gives permission to link the code of this program with any library,
 %   and distribute linked combinations of it. You must obey the GNU
 %   General Public License in all respects for all of the code in the

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/pnet_putvar.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/pnet_putvar.m
@@ -13,7 +13,7 @@ function pnet_putvar(con,varargin)
 %  
 
   
-%   This file(s) is part of the tcp_udp_ip toolbox (C) Peter Rydesäter et al.  
+%   This file(s) is part of the tcp_udp_ip toolbox (C) Peter Rydesaeter et al.  
 %   et al.  1998-2003 for running in MATLAB(R) as scripts and/or plug-ins.
 %
 %   This program is free software; you can redistribute it and/or modify
@@ -30,7 +30,7 @@ function pnet_putvar(con,varargin)
 %   along with this program; if not, write to the Free Software
 %   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 %
-%   In addition, as a SPECIAL EXCEPTION, Peter Rydesäter, SWEDEN,
+%   In addition, as a SPECIAL EXCEPTION, Peter Rydesaeter, SWEDEN,
 %   gives permission to link the code of this program with any library,
 %   and distribute linked combinations of it. You must obey the GNU
 %   General Public License in all respects for all of the code in the

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/pnet_remote.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/pnet_remote.m
@@ -2,7 +2,7 @@ function varargout=pnet_remote(varargin)
 % PNET_REMOTE   - Evaluation of matlab expression in remote host PNET
 %
 %     Version: First includes in the tcp/udp/ip toolbox 2002-02-13
-%              (C) 2002 Peter Rydesäter, GNU Public License 
+%              (C) 2002 Peter Rydesaeter, GNU Public License 
 %
 %     This function uses PNET for nonblocking remote controll of other matlab 
 %     session on this or other hosts. This function implements different client
@@ -113,7 +113,7 @@ function varargout=pnet_remote(varargin)
 %
  
 
-%   This file(s) is part of the tcp_udp_ip toolbox (C) Peter Rydesäter et al.  
+%   This file(s) is part of the tcp_udp_ip toolbox (C) Peter Rydesaeter et al.  
 %   et al.  1998-2003 for running in MATLAB(R) as scripts and/or plug-ins.
 %
 %   This program is free software; you can redistribute it and/or modify
@@ -130,7 +130,7 @@ function varargout=pnet_remote(varargin)
 %   along with this program; if not, write to the Free Software
 %   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 %
-%   In addition, as a SPECIAL EXCEPTION, Peter Rydesäter, SWEDEN,
+%   In addition, as a SPECIAL EXCEPTION, Peter Rydesaeter, SWEDEN,
 %   gives permission to link the code of this program with any library,
 %   and distribute linked combinations of it. You must obey the GNU
 %   General Public License in all respects for all of the code in the

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/tcpip/Contents.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/tcpip/Contents.m
@@ -1,6 +1,6 @@
 %  Tcpip toolbox version 1.2.x  2000-12-14 for MATLAB 5.x 6.x
 %
-%  Copyrigtht (C) Peter Rydesäter 1998 - 2000, Mitthögskolan, SWEDEN
+%  Copyrigtht (C) Peter Rydesaeter 1998 - 2000, Mitthoegskolan, SWEDEN
 %
 %  This program is free software; you can redistribute it and/or
 %  modify it under the terms of the GNU General Public License
@@ -21,9 +21,9 @@
 %  Main implementation:              Implementation of windows support:
 %  ===================
 %
-%  Peter Rydesäter                   Mario Bergeron
-%  Mitthögskolan                     LYR Signal Processing
-%  Östersund,Sweden                  Québec, Canada
+%  Peter Rydesaeter                  Mario Bergeron
+%  Mitthoegskolan                    LYR Signal Processing
+%  Oestersund,Sweden                 Quebec, Canada
 %  e-mail:Peter.Rydesater@ite.mh.se  e-mail: Mario.Bergeron@lyre.qc.ca
 %  
 %

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/udp_plotter_demo.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/udp_plotter_demo.m
@@ -8,7 +8,7 @@ function udp_plotter_demo(lport)
 % This script is a demo that listen for a UDP packet (default port 3333) and
 % uses PLOT to dplay the sequence of doubles in the packet.
 %
-% (C) 2002 Peter Rydesäter
+% (C) 2002 Peter Rydesaeter
 
 % Add default argument
 if nargin<1, lport=3333; end

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/udp_plotter_demo_OSX.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/udp_plotter_demo_OSX.m
@@ -8,7 +8,7 @@ function udp_plotter_demo(lport)
 % This script is a demo that listen for a UDP packet (default port 3333) and
 % uses PLOT to dplay the sequence of doubles in the packet.
 %
-% (C) 2002 Peter Rydesäter
+% (C) 2002 Peter Rydesaeter
 
 % Add default argument
 if nargin<1, lport=3333; end

--- a/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/webserver_demo.m
+++ b/Psychtoolbox/PsychHardware/iViewXToolbox/tcp_udp_ip/webserver_demo.m
@@ -33,7 +33,7 @@ try,
                 str=evalc('random_numbers=rand(5)');
                 pnet(con,'printf','<h2>Some random numbers</h2>\n<pre>%s</pre>\n',str);
                 pnet(con,'printf','<a href="./">Reload page with new numbers>></a>');
-                pnet(con,'printf','<hr><I>(C) 2002 Peter Rydesäter, Mitthögskolan, Östersund, SWEDEN</I></body></html>\n');
+                pnet(con,'printf','<hr><I>(C) 2002 Peter Rydesaeter, Mitthoegskolan, Oestersund, SWEDEN</I></body></html>\n');
             end
             pnet(con,'close');
             drawnow;

--- a/Psychtoolbox/PsychOneliners/AppleVersion.m
+++ b/Psychtoolbox/PsychOneliners/AppleVersion.m
@@ -40,11 +40,11 @@ function versionString=AppleVersion(gestaltString)
 % This selector returns the majorRev field of the NumVersion record as
 % hexadecimal instead of the usual BCD.
 % 
-% #define gestaltGestaltKaputVersion 'G K ' /* Gestalt Kaput */
+% #define gestaltGestaltKaputVersion 'G\0xa0K\0xa0' /* Gestalt Kaput */
 % NOTE: Both the t characters are actually the option-t character
 % (0xA0).
 % 
-% #define gestaltGestaltVersion 'GŠst' /* Gestalt version */
+% #define gestaltGestaltVersion 'G\0x8ast' /* Gestalt version */
 % NOTE: The "a" is actually the option-u/a character (0x8A).
 % #define gestaltUniversalDiskFormatVersion? 'kudf'
 

--- a/Psychtoolbox/PsychOneliners/AssertOSX.m
+++ b/Psychtoolbox/PsychOneliners/AssertOSX.m
@@ -34,12 +34,12 @@ function AssertOSX
 % platform independence.  
 %
 % Overview- New functions for OS X fall into one of these categories:
-%  ¥ OpenGL-specific functions which are a permanent departure from earlier
+%  * OpenGL-specific functions which are a permanent departure from earlier
 %   Psychtoolboxes.  Call IsOpenGL or AssertOpenGL if you use only these. 
-%  ¥ Functions which take advantage of features unique to a specific
+%  * Functions which take advantage of features unique to a specific
 %  operating system.  When possible, avoid these by using platform-neutral
 %   overlay functions. 
-%  ¥ Remaining differences are a temporary failure to keep the OS 9,
+%  * Remaining differences are a temporary failure to keep the OS 9,
 %  Windows, and OS X Psychtoolboxes synchronized during the course of
 %  development. The AssertOSX script is itself an example of this; it has
 %  not been ported back to OS 9 and Windows Psychtoolboxes yet.

--- a/Psychtoolbox/PsychPriority/MaxPriority.m
+++ b/Psychtoolbox/PsychPriority/MaxPriority.m
@@ -78,11 +78,11 @@ function priorityLevel=MaxPriority(varargin)
 % NOTES
 % 7/17/04 awi
 % The OS X section does not do thorough validation of arguments.  It does do:
-%  ¥If the window pointer or screen number argument is present it checks that it is
+%  * If the window pointer or screen number argument is present it checks that it is
 %  valid.
-%  ¥If a command is included, it checks that it is a valid command
+%  * If a command is included, it checks that it is a valid command
 %  for MacPriority.
-%  ¥It checks that at least one argument was passed.
+%  * It checks that at least one argument was passed.
 %
 % It does not check other requirements, for example some command arguments
 % require the screen number or window pointer.

--- a/Psychtoolbox/PsychRects/RectOfMatrix.m
+++ b/Psychtoolbox/PsychRects/RectOfMatrix.m
@@ -10,7 +10,7 @@ function rect = RectOfMatrix(mat)
 % 6/28/04   awi Wrote it.
 % 7/13/04   awi Improved documentation.  
 % 1/29/05   dgp Renamed from RectFromMatrix to RectOfMatrix. 
-% 1/29/05   dgp Timed it. RectOfMatrix is quick, taking about 100 µs, 
+% 1/29/05   dgp Timed it. RectOfMatrix is quick, taking about 100 us, 
 %               independent of matrix size.
 % 11/24/05  mk  Bugfix. Didn't work for multi-layer (3D) matrices.
 

--- a/Psychtoolbox/Quest/QuestBetaAnalysis.m
+++ b/Psychtoolbox/Quest/QuestBetaAnalysis.m
@@ -26,7 +26,7 @@ if nargin<2
 end
 fprintf('Now re-analyzing with both threshold and beta as free parameters. ...\n');
 for f=fid
-	fprintf(f,'logC 	 ±sd 	 beta	 ±sd	 gamma\n');
+	fprintf(f,'logC 	 +-sd 	 beta	 +-sd	 gamma\n');
 end
 for i=1:length(q(:))
 	betaEstimate(i)=QuestBetaAnalysis1(q(i),fid);
@@ -77,7 +77,7 @@ betaSd=sqrt(sum(p2.*beta2.^2)/p-(sum(p2.*beta2)/p).^2);
 iBetaMean=sum(p2./beta2)/p;
 iBetaSd=sqrt(sum(p2./beta2.^2)/p-(sum(p2./beta2)/p).^2);
 for f=fid
-	%	fprintf(f,'Threshold %4.2f ± %.2f; Beta mode %.1f mean %.1f ± %.1f imean 1/%.1f ± %.1f; Gamma %.2f\n',t,sd,q2(i).beta,betaMean,betaSd,1/iBetaMean,iBetaSd,q.gamma);
+	%	fprintf(f,'Threshold %4.2f +- %.2f; Beta mode %.1f mean %.1f +- %.1f imean 1/%.1f +- %.1f; Gamma %.2f\n',t,sd,q2(i).beta,betaMean,betaSd,1/iBetaMean,iBetaSd,q.gamma);
 	%	fprintf(f,'%5.2f	%4.1f	%5.2f\n',t,1/iBetaMean,q.gamma);
 	fprintf(f,'%5.2f	%5.2f	%4.1f	%4.1f	%6.3f\n',t,sd,1/iBetaMean,betaSd,q.gamma);
 end

--- a/Psychtoolbox/Quest/QuestDemo.m
+++ b/Psychtoolbox/Quest/QuestDemo.m
@@ -166,8 +166,8 @@ beta=3.5;delta=0.01;gamma=0.5;
 q=QuestCreate(tGuess,tGuessSd,pThreshold,beta,delta,gamma);
 q.normalizePdf=1; % This adds a few ms per call to QuestUpdate, but otherwise the pdf will underflow after about 1000 trials.
 
-% fprintf('Your initial guess was %g ± %g\n',tGuess,tGuessSd);
-% fprintf('Quest''s initial threshold estimate is %g ± %g\n',QuestMean(q),QuestSd(q));
+% fprintf('Your initial guess was %g +- %g\n',tGuess,tGuessSd);
+% fprintf('Quest''s initial threshold estimate is %g +- %g\n',QuestMean(q),QuestSd(q));
 
 % Simulate a series of trials. 
 % On each trial we ask Quest to recommend an intensity and we call QuestUpdate to save the result in q.
@@ -199,11 +199,11 @@ fprintf('%.0f ms/trial\n',1000*(eval(getSecsFunction)-timeZero)/trialsDesired);
 % Ask Quest for the final estimate of threshold.
 t=QuestMean(q);		% Recommended by Pelli (1989) and King-Smith et al. (1994). Still our favorite.
 sd=QuestSd(q);
-fprintf('Final threshold estimate (mean±sd) is %.2f ± %.2f\n',t,sd);
+fprintf('Final threshold estimate (mean+-sd) is %.2f +- %.2f\n',t,sd);
 % t=QuestMode(q);	% Similar and preferable to the maximum likelihood recommended by Watson & Pelli (1983). 
 % fprintf('Mode threshold estimate is %4.2f\n',t);
 fprintf('\nYou set the true threshold to %.2f.\n',tActual);
-fprintf('Quest knew only your guess: %.2f ± %.2f.\n',tGuess,tGuessSd);
+fprintf('Quest knew only your guess: %.2f +- %.2f.\n',tGuess,tGuessSd);
 
 % Optionally, reanalyze the data with beta as a free parameter.
 fprintf('\nBETA. Many people ask, so here''s how to analyze the data with beta as a free\n');


### PR DESCRIPTION
where source codepage is unidentified. Could be latin1, could be whatever. Just eliminate them. 

`±` became `+-` and `Rydesäter` became `Rydesaeter`, etc

Also purge stupid Apple typographic quote “characters” in source code comments.

If you want to use fancy glyphs, there’s no excuse not to use utf-8 today. But considering  this is your **source code**, and how shabby matlab handling of anything other than ASCII is, you better not.
