### PR TITLE
autobuild tests for Octave in Linux & OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: octave
+
+os:
+  - linux
+  - osx
+
+compiler:
+  - gcc
+  - clang
+
+addons:
+  apt:
+    packages:
+      - mplayer
+    
+before install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install mplayer fontconfig ftgl; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install octave --with-gui; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -O- http://neuro.debian.net/lists/xenial.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-key adv --recv-keys --keyserver hkp://pgp.mit.edu:80 0xA5D32F012649A5A9; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y mplayer fontconfig; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y octave; fi
+
+script:
+  - cd Psychtoolbox
+  - yes|octave --eval 'SetupPsychtoolbox.m'


### PR DESCRIPTION
For this to work, we should also make sure that `SetupPsychtoolbox.m` has correct exit status. `SetupPsychtoolbox.m` might not even be enough for the build tests. In that case, we could call a bash shell script which runs all necessary tests then exits with a meaningful status. 
This script could be a good starting point to automate building and checking on different platforms for Octave. Maybe we would even want to test Octave 3 and Octave 4 branches independently.  