### PR TITLE
Strange interaction between DATAPixx2, NVIDIA 361, and IdentityClut

### DIFF
--- a/Psychtoolbox/PsychHardware/BitsPlusToolbox/BitsPlusTests/BitsPlusImagingPipelineTest.m
+++ b/Psychtoolbox/PsychHardware/BitsPlusToolbox/BitsPlusTests/BitsPlusImagingPipelineTest.m
@@ -82,15 +82,6 @@ if answer == 's'
     BitsPlusPlus('OpenBits#', bitsSharpPortName);
 end
 
-% Device specific low-level diagnostics to be run?
-if (answer == 'd') || (answer == 's') 
-    answer = input('Run external DataPixx/ViewPixx/ProPixx/Bits# device diagnostics as well [Time consuming]? [y/n] ', 's');
-    if answer == 'y'
-        % Enable one-shot diagnostic of GPU encoders via DataPixx et al. or Bits#:
-        BitsPlusPlus('TestGPUEncoders');
-    end
-end
-
 oldverbosity = Screen('Preference', 'Verbosity', 2);
 oldsynclevel = Screen('Preference', 'SkipSyncTests', 2);
 


### PR DESCRIPTION
Config: Xubuntu 16.04 LTS, Quadro K620, NVIDIA driver 361.42, VPixx DATAPixx2, on NeuroDebian PTB-3: 3.0.12.20160514.dfsg1-1~nd16.04+1.

PsychGPUTestAndTweakGammaTables fails to find an identity clut mapping after 256 tweak iterations when run via BitsPlusImagingPipelineTest (selecting 'd' then 'y'). Visually, I see the luminance gradient briefly before it disappears into black, and then the script runs through each iteration reporting "765 mismatching pixels". So, I think each read consists solely of black pixels.

I do know that the type-III LUT is the proper mapping and requires no tweaks on this setup, but there may be some NVIDIA driver issue that needs a workaround.

I discovered three things to make this test work:
- Not skipping the sync tests (SkipSyncTests == 0) gives proper behaviour (changing 2 to 0 on [this line](https://github.com/kleinerm/Psychtoolbox-3/blob/686b073f070d5d5484d609cce1edcb64a725a214/Psychtoolbox/PsychHardware/BitsPlusToolbox/BitsPlusTests/BitsPlusImagingPipelineTest.m#L95))
- Unchecking "Allow Flipping" under OpenGL Settings in NVIDIA X Server Settings
- Using the nouveau driver

Here's a small script to reproduce the SkipSyncTests issue:
```matlab
clear all;
skipsync = 0; % change to 1 to hit the bug
if skipsync
    old = Screen('Preference', 'SkipSyncTests', 2);
end

PsychImaging('PrepareConfiguration');
PsychImaging('AddTask', 'General', 'EnableDataPixxC48Output', 0);
BitsPlusPlus('TestGPUEncoders');
PsychImaging('OpenWindow', max(Screen('Screens')), 0, []);
WaitSecs(2);
sca;

if skipsync
    Screen('Preference', 'SkipSyncTests', old);
end
```