### PR TITLE
Screen: fix warnings from GCC 5.4's -Wall -Wextra

### DIFF
--- a/PsychSourceGL/Source/Common/Base/MiniBox.c
+++ b/PsychSourceGL/Source/Common/Base/MiniBox.c
@@ -130,17 +130,20 @@ char *int2str(psych_int64 num)
 
 size_t PsychIndexElementFrom2DArray(size_t mDim/*|Y|*/, size_t nDim/*|X|*/, size_t m/*y*/, size_t n/*x*/)
 {
+	(void) nDim;
 	return(n*mDim + m);  
 }
 
 size_t PsychIndexElementFrom3DArray(size_t mDim/*|Y|*/, size_t nDim/*|X|*/, size_t pDim/*|Z|*/, size_t m/*y*/, size_t n/*x*/, size_t p/*z*/)
-{	
+{
+	(void) pDim;
 	return(p*mDim*nDim + n*mDim + m);  //planeindex * planesize + columnindex * columsize + rowindex    
 }
 
 size_t PsychIndexPlaneFrom3DArray(size_t mDim, size_t nDim, size_t pDim, size_t planeIndex)
 {
-        return(planeIndex*mDim*nDim);
+	(void) pDim;
+	return(planeIndex*mDim*nDim);
 }
 
 psych_int64 maxInt(psych_int64 a, psych_int64 b)

--- a/PsychSourceGL/Source/Common/Base/PsychInit.c
+++ b/PsychSourceGL/Source/Common/Base/PsychInit.c
@@ -59,10 +59,9 @@ PsychError PsychInit(void)
 PsychError PsychExit(void)
 {
     PsychFunctionPtr projectExit;
-    PsychError error;
 
     projectExit = PsychGetProjectExitFunction();
-    if(projectExit != NULL) error=(*projectExit)();
+    if(projectExit != NULL) (*projectExit)();
 
     // Put whatever cleanup of the Psychtoolbox is required here.
     PsychExitTimeGlue();

--- a/PsychSourceGL/Source/Common/Base/PsychVersioning.c
+++ b/PsychSourceGL/Source/Common/Base/PsychVersioning.c
@@ -140,21 +140,3 @@ int PsychGetPointVersionNumber(void)
 {
 	return(PSYCHTOOLBOX_POINT_VERSION);
 }
-
-
-/* PsychSetModuleAuthor()
-
-	Information about Psychtoolbox authors, such as their names and email addresss, is returned by the module command "version", along with 
-	version numbers.  For example, "Screen('Version')".  For all Psychtoolbox mex files there is one canonical source for this information,
-	the file MODULEVersion.c shared between all mex files which provide the "Version" command.  Becausue not all Psychtoolbox authors 
-	are authors on all modules, we provide a mechanism to enable reporting of particular authors for particular modules.  From within
-	the function PsychModuleInit in your module source call PsychSetModuleAuthor() once for each author which you want to register.  
-	once for each author.  PsychSetModuleAuthor identifies authors by their initials, which you can find find in MODULEVersion.c.   
-*/	
-void PsychSetModuleAuthor(char *initials)
-{
-	
-
-}
-
-

--- a/PsychSourceGL/Source/Common/Screen/PsychGLGlue.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychGLGlue.c
@@ -845,7 +845,7 @@ void PsychGLRectd(PsychWindowRecordType *windowRecord, double x1, double y1, dou
 void PsychDrawDisc(PsychWindowRecordType *windowRecord, float xc, float yc, float innerRadius, float outerRadius, int numSlices, float xScale, float yScale, float startAngle, float arcAngle)
 {
     float Rads, outerX, outerY, innerX, innerY;
-	int i, count = 0;
+	int i;
 	#ifndef M_PI
 	#define M_PI 3.141592654
 	#endif
@@ -857,6 +857,7 @@ void PsychDrawDisc(PsychWindowRecordType *windowRecord, float xc, float yc, floa
     startAngle = (float) (M_PI/2 - startAngle * 2 * M_PI / 360);
 
     /* Disable for now, do it slooow ...
+       int count = 0;
        float *vertices = PsychMallocTemp(sizeof(float) * 4 * (numSlices + 1));
        memset(vertices, 0, sizeof(float) * 4 * (numSlices + 1));
     */

--- a/PsychSourceGL/Source/Common/Screen/PsychGraphicsHardwareHALSupport.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychGraphicsHardwareHALSupport.c
@@ -766,7 +766,8 @@ psych_bool PsychWaitForBufferswapPendingOrFinished(PsychWindowRecordType* window
 
     // If we are called, we know that 'windowRecord' is an onscreen window.
     int screenId = windowRecord->screenNumber;
-    int headid = PsychScreenToCrtcId(screenId, 0);
+    
+    PsychScreenToCrtcId(screenId, 0);
 
     // Retrieve display id and screen size spec that is needed later...
     PsychGetCGDisplayIDFromScreenNumber(&displayID, screenId);

--- a/PsychSourceGL/Source/Common/Screen/PsychImagingPipelineSupport.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychImagingPipelineSupport.c
@@ -1362,6 +1362,8 @@ GLuint PsychCreateGLSLProgram(const char* fragmentsrc, const char* vertexsrc, co
     GLint status;
     char errtxt[10000];
 
+    (void) primitivesrc;
+
     // Reset error state:
     while (glGetError());
 
@@ -2604,6 +2606,9 @@ void PsychShutdownImagingPipeline(PsychWindowRecordType *windowRecord, psych_boo
 void PsychPipelineListAllHooks(PsychWindowRecordType *windowRecord)
 {
     int i;
+
+    (void) windowRecord;
+
     printf("PTB-INFO: The Screen command currently provides the following hook functions:\n");
     printf("=============================================================================\n");
     for (i=0; i<MAX_SCREEN_HOOKS; i++) {
@@ -3380,7 +3385,6 @@ int PsychPipelineProcessMacros(PsychWindowRecordType *windowRecord, char* cmdStr
 psych_bool PsychPipelineExecuteHookSlot(PsychWindowRecordType *windowRecord, int hookId, PsychHookFunction* hookfunc, void* hookUserData, void* hookBlitterFunction, psych_bool srcIsReadonly, psych_bool allowFBOSwizzle, PsychFBO** srcfbo1, PsychFBO** srcfbo2, PsychFBO** dstfbo, PsychFBO** bouncefbo)
 {
     psych_bool dispatched = FALSE;
-    char* execString = NULL;
 
     // Dispatch by hook function type:
     switch(hookfunc->hookfunctype) {
@@ -3795,6 +3799,8 @@ psych_bool PsychBlitterIdentity(PsychWindowRecordType *windowRecord, PsychHookFu
     char* strp;
     psych_bool bilinearfiltering;
 
+    (void) srcIsReadonly, (void) allowFBOSwizzle, (void) srcfbo2, (void) dstfbo, (void) bouncefbo;
+
     // hookUserData, if non-NULL, can provide override parameter string:
     char* pString1 = (hookUserData) ? (char*) hookUserData : hookfunc->pString1;
 
@@ -4009,6 +4015,8 @@ psych_bool PsychBlitterDisplayList(PsychWindowRecordType *windowRecord, PsychHoo
     float sx, sy;
     char* strp;
     psych_bool bilinearfiltering;
+
+    (void) hookUserData, (void) srcIsReadonly, (void) allowFBOSwizzle, (void) srcfbo2, (void) dstfbo, (void) bouncefbo;
 
     // Not available on non-classic OpenGL. Need to find some replacement for display lists at some point in time to make this work :(
     if (!PsychIsGLClassic(windowRecord)) {

--- a/PsychSourceGL/Source/Common/Screen/PsychMovieSupportGStreamer.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychMovieSupportGStreamer.c
@@ -242,6 +242,9 @@ static gboolean PsychMovieBusCallback(GstBus *bus, GstMessage *msg, gpointer dat
 {
     GstSeekFlags rewindFlags = 0;
     PsychMovieRecordType* movie = (PsychMovieRecordType*) dataptr;
+
+    (void) bus;
+
     if (PsychPrefStateGet_Verbosity() > 11) printf("PTB-DEBUG: PsychMovieBusCallback: Msg source name and type: %s : %s\n", GST_MESSAGE_SRC_NAME(msg), GST_MESSAGE_TYPE_NAME(msg));
 
     switch (GST_MESSAGE_TYPE (msg)) {
@@ -349,12 +352,14 @@ static gboolean PsychMovieBusCallback(GstBus *bus, GstMessage *msg, gpointer dat
 /* Called at each end-of-stream event at end of playback: */
 static void PsychEOSCallback(GstAppSink *sink, gpointer user_data)
 {
-    PsychMovieRecordType* movie = (PsychMovieRecordType*) user_data;
+    (void) sink, (void) user_data;
 
+    //PsychMovieRecordType* movie = (PsychMovieRecordType*) user_data;
     //PsychLockMutex(&movie->mutex);
     //printf("PTB-DEBUG: Videosink reached EOS.\n");
     //PsychSignalCondition(&movie->condition);
     //PsychUnlockMutex(&movie->mutex);
+
     return;
 }
 
@@ -364,6 +369,8 @@ static void PsychEOSCallback(GstAppSink *sink, gpointer user_data)
  */
 static GstFlowReturn PsychNewPrerollCallback(GstAppSink *sink, gpointer user_data)
 {
+    (void) sink;
+
     PsychMovieRecordType* movie = (PsychMovieRecordType*) user_data;
 
     PsychLockMutex(&movie->mutex);
@@ -380,8 +387,9 @@ static GstFlowReturn PsychNewPrerollCallback(GstAppSink *sink, gpointer user_dat
  */
 static GstFlowReturn PsychNewBufferCallback(GstAppSink *sink, gpointer user_data)
 {
-    PsychMovieRecordType* movie = (PsychMovieRecordType*) user_data;
+    (void) sink;
 
+    PsychMovieRecordType* movie = (PsychMovieRecordType*) user_data;
     PsychLockMutex(&movie->mutex);
     //printf("PTB-DEBUG: New Buffer received.\n");
     movie->frameAvail++;
@@ -392,10 +400,12 @@ static GstFlowReturn PsychNewBufferCallback(GstAppSink *sink, gpointer user_data
 }
 
 /* Not used by us, but needs to be defined as no-op anyway: */
+/* // There are only 3 function pointers in GstAppSinkCallbacks now
 static GstFlowReturn PsychNewBufferListCallback(GstAppSink *sink, gpointer user_data)
 {
-    PsychMovieRecordType* movie = (PsychMovieRecordType*) user_data;
+    (void) sink, (void) user_data;
 
+    //PsychMovieRecordType* movie = (PsychMovieRecordType*) user_data;
     //PsychLockMutex(&movie->mutex);
     //printf("PTB-DEBUG: New Bufferlist received.\n");
     //PsychSignalCondition(&movie->condition);
@@ -403,10 +413,13 @@ static GstFlowReturn PsychNewBufferListCallback(GstAppSink *sink, gpointer user_
 
     return(GST_FLOW_OK);
 }
+*/
 
 /* Not used by us, but needs to be defined as no-op anyway: */
 static void PsychDestroyNotifyCallback(gpointer user_data)
 {
+    (void) user_data;
+
     return;
 }
 
@@ -431,25 +444,28 @@ static void PsychMovieAboutToFinishCB(GstElement *theMovie, gpointer user_data)
 }
 
 /* Not used, didn't work, but left here in case we find a use for it in the future. */
+/*
 static void PsychMessageErrorCB(GstBus *bus, GstMessage *msg)
 {
-      gchar  *debug;
-      GError *error;
+    gchar  *debug;
+    GError *error;
 
-      gst_message_parse_error (msg, &error, &debug);
-      g_free (debug);
+    (void) bus;
 
-      printf("PTB-BUSERROR: %s\n", error->message);
-      g_error_free (error);
-	return;
+    gst_message_parse_error (msg, &error, &debug);
+    g_free (debug);
+
+    printf("PTB-BUSERROR: %s\n", error->message);
+    g_error_free (error);
+    return;
 }
+*/
 
 static GstAppSinkCallbacks videosinkCallbacks = {
     PsychEOSCallback,
     PsychNewPrerollCallback,
     PsychNewBufferCallback,
-    PsychNewBufferListCallback,
-    NULL
+    {0}
 };
 
 /*
@@ -474,8 +490,6 @@ void PsychGSCreateMovie(PsychWindowRecordType *win, const char* moviename, doubl
     GstCaps         *colorcaps = NULL;
     GstElement      *theMovie = NULL;
     GstElement      *videocodec = NULL;
-    GMainLoop       *MovieContext = NULL;
-    GstBus          *bus = NULL;
     GstElement      *videosink = NULL;
     GstElement      *audiosink;
     gchar*          pstring;
@@ -487,9 +501,7 @@ void PsychGSCreateMovie(PsychWindowRecordType *win, const char* moviename, doubl
     gint            rate1, rate2;
     int             i, slotid;
     int             max_video_threads;
-    GError          *error = NULL;
     char            movieLocation[FILENAME_MAX];
-    psych_bool      trueValue = TRUE;
     psych_bool      printErrors;
     GstIterator     *it;
     psych_bool      done;
@@ -1336,7 +1348,6 @@ int PsychGSGetTextureFromMovie(PsychWindowRecordType *win, int moviehandle, int 
                                 PsychWindowRecordType *out_texture, double *presentation_timestamp)
 {
     GstElement      *theMovie;
-    unsigned int    failcount=0;
     double          rate;
     double          targetdelta, realdelta, frames;
     GstBuffer       *videoBuffer = NULL;
@@ -1348,11 +1359,7 @@ int PsychGSGetTextureFromMovie(PsychWindowRecordType *win, int moviehandle, int 
     double          tNow;
     double          preT, postT;
     unsigned char*  releaseMemPtr = NULL;
-    #pragma warning( disable : 4068 )
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     GstMapInfo      mapinfo = GST_MAP_INFO_INIT;
-    #pragma GCC diagnostic pop
 
     if (!PsychIsOnscreenWindow(win)) {
         PsychErrorExitMsg(PsychError_user, "Need onscreen window ptr!!!");

--- a/PsychSourceGL/Source/Common/Screen/PsychMovieSupportGStreamer.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychMovieSupportGStreamer.c
@@ -1359,7 +1359,13 @@ int PsychGSGetTextureFromMovie(PsychWindowRecordType *win, int moviehandle, int 
     double          tNow;
     double          preT, postT;
     unsigned char*  releaseMemPtr = NULL;
+#if PSYCH_SYSTEM == PSYCH_WINDOWS
+    #pragma warning( disable : 4068 )
+#endif
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     GstMapInfo      mapinfo = GST_MAP_INFO_INIT;
+    #pragma GCC diagnostic pop
 
     if (!PsychIsOnscreenWindow(win)) {
         PsychErrorExitMsg(PsychError_user, "Need onscreen window ptr!!!");

--- a/PsychSourceGL/Source/Common/Screen/PsychMovieWritingSupportGStreamer.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychMovieWritingSupportGStreamer.c
@@ -373,11 +373,7 @@ psych_bool PsychAddAudioBufferToMovie(int moviehandle, unsigned int nrChannels, 
     float               v;
     unsigned int        n, i;
     GstBuffer*          pushBuffer;
-    #pragma warning( disable : 4068 )
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     GstMapInfo          mapinfo = GST_MAP_INFO_INIT;
-    #pragma GCC diagnostic pop
 
     // Child protection: Audio writing enabled for this movie?
     if (NULL == pwriterRec->ptbaudioappsrc) {
@@ -497,6 +493,8 @@ static psych_bool PsychMoviePipelineSetState(GstElement* camera, GstState state,
 /* Receive messages from the pipeline message bus and handle them: */
 static gboolean PsychMovieBusCallback(GstBus *bus, GstMessage *msg, gpointer dataptr)
 {
+  (void) bus;
+
   PsychMovieWriterRecordType* dev = (PsychMovieWriterRecordType*) dataptr;
   if (PsychPrefStateGet_Verbosity() > 11) printf("PTB-DEBUG: PsychMovieWriterBusCallback: Msg source name and type: %s : %s\n", GST_MESSAGE_SRC_NAME(msg), GST_MESSAGE_TYPE_NAME(msg));
 

--- a/PsychSourceGL/Source/Common/Screen/PsychMovieWritingSupportGStreamer.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychMovieWritingSupportGStreamer.c
@@ -373,7 +373,13 @@ psych_bool PsychAddAudioBufferToMovie(int moviehandle, unsigned int nrChannels, 
     float               v;
     unsigned int        n, i;
     GstBuffer*          pushBuffer;
+#if PSYCH_SYSTEM == PSYCH_WINDOWS
+    #pragma warning( disable : 4068 )
+#endif
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     GstMapInfo          mapinfo = GST_MAP_INFO_INIT;
+    #pragma GCC diagnostic pop
 
     // Child protection: Audio writing enabled for this movie?
     if (NULL == pwriterRec->ptbaudioappsrc) {

--- a/PsychSourceGL/Source/Common/Screen/PsychTextureSupport.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychTextureSupport.c
@@ -1386,6 +1386,8 @@ void PsychBatchBlitTexturesToDisplay(unsigned int opMode, unsigned int count, Ps
     static GLdouble sourceWidth, sourceHeight;
     GLdouble sourceX, sourceY, sourceXEnd, sourceYEnd;
 
+    (void) count;
+
     if (opMode == 0) {
         // Start new batch:
         if (vertices || colors || texcoords)

--- a/PsychSourceGL/Source/Common/Screen/PsychVideoCaptureSupportGStreamer.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychVideoCaptureSupportGStreamer.c
@@ -2820,7 +2820,13 @@ static GstPadProbeReturn PsychHaveVideoDataCallback(GstPad *pad, GstPadProbeInfo
     unsigned char *input_image;
     PsychVidcapRecordType *capdev = (PsychVidcapRecordType *) dataptr;
     GstBuffer *videoBuffer = info->data;
-    GstMapInfo mapinfo = GST_MAP_INFO_INIT;
+#if PSYCH_SYSTEM == PSYCH_WINDOWS
+    #pragma warning( disable : 4068 )
+#endif
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+    GstMapInfo      mapinfo = GST_MAP_INFO_INIT;
+    #pragma GCC diagnostic pop
 
     (void) pad;
 
@@ -4512,7 +4518,16 @@ int PsychGSGetTextureFromCapture(PsychWindowRecordType *win, int capturehandle, 
     int nrdropped = 0;
     unsigned char* input_image = NULL;
 
+    // Disable warning about missing field initializer in calls
+    // like GstMapInfo mapinfo = = GST_MAP_INFO_INIT;
+    // Not our bug, but GStreamer's, so suppress for now.
+#if PSYCH_SYSTEM == PSYCH_WINDOWS
+    #pragma warning( disable : 4068 )
+#endif
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     GstMapInfo mapinfo = GST_MAP_INFO_INIT;
+    #pragma GCC diagnostic pop
 
     (void) timeindex;
 

--- a/PsychSourceGL/Source/Common/Screen/PsychVideoCaptureSupportGStreamer.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychVideoCaptureSupportGStreamer.c
@@ -480,7 +480,8 @@ static psych_bool PsychVideoPipelineSetState(GstElement* camera, GstState state,
 /* Receive messages from the playback pipeline message bus and handle them: */
 static gboolean PsychVideoBusCallback(GstBus *bus, GstMessage *msg, gpointer dataptr)
 {
-    PsychVidcapRecordType* capdev = (PsychVidcapRecordType*) dataptr;
+    (void) bus, (void) dataptr;
+
     if (PsychPrefStateGet_Verbosity() > 11) printf("PTB-DEBUG: PsychVideoBusCallback: Msg source name and type: %s : %s\n", GST_MESSAGE_SRC_NAME(msg), GST_MESSAGE_TYPE_NAME(msg));
 
     switch (GST_MESSAGE_TYPE (msg)) {
@@ -539,8 +540,9 @@ static gboolean PsychVideoBusCallback(GstBus *bus, GstMessage *msg, gpointer dat
 /* Called at each end-of-stream event at end of playback: */
 static void PsychEOSCallback(GstAppSink *sink, gpointer user_data)
 {
-    PsychVidcapRecordType* capdev = (PsychVidcapRecordType*) user_data;
+    (void) sink;
 
+    PsychVidcapRecordType* capdev = (PsychVidcapRecordType*) user_data;
     PsychLockMutex(&capdev->mutex);
     printf("PTB-DEBUG: Videosink reached EOS.\n");
     // Signal EOS to trigger an abort of device open sequence:
@@ -585,6 +587,8 @@ static GstFlowReturn PsychNewPrerollCallback(GstAppSink *sink, gpointer user_dat
     GstSample *videoSample;
     int w = 0, h = 0;
 
+    (void) sink;
+
     PsychVidcapRecordType* capdev = (PsychVidcapRecordType*) user_data;
 
     PsychLockMutex(&capdev->mutex);
@@ -618,6 +622,8 @@ static GstFlowReturn PsychNewPrerollCallback(GstAppSink *sink, gpointer user_dat
  */
 static GstFlowReturn PsychNewBufferCallback(GstAppSink *sink, gpointer user_data)
 {
+    (void) sink;
+
     PsychVidcapRecordType* capdev = (PsychVidcapRecordType*) user_data;
 
     PsychLockMutex(&capdev->mutex);
@@ -630,8 +636,11 @@ static GstFlowReturn PsychNewBufferCallback(GstAppSink *sink, gpointer user_data
 }
 
 /* Not used by us, but needs to be defined as no-op anyway: */
+/*
 static GstFlowReturn PsychNewBufferListCallback(GstAppSink *sink, gpointer user_data)
 {
+    (void) sink;
+
     PsychVidcapRecordType* capdev = (PsychVidcapRecordType*) user_data;
 
     PsychLockMutex(&capdev->mutex);
@@ -640,10 +649,12 @@ static GstFlowReturn PsychNewBufferListCallback(GstAppSink *sink, gpointer user_
 
     return(GST_FLOW_OK);
 }
+*/
 
 /* Not used by us, but needs to be defined as no-op anyway: */
 static void PsychDestroyNotifyCallback(gpointer user_data)
 {
+    (void) user_data;
     return;
 }
 
@@ -651,8 +662,7 @@ static GstAppSinkCallbacks videosinkCallbacks = {
     PsychEOSCallback,
     PsychNewPrerollCallback,
     PsychNewBufferCallback,
-    PsychNewBufferListCallback,
-    NULL
+    {0}
 };
 
 /*
@@ -743,10 +753,11 @@ static void PsychGSProbeGstDevice(GstDevice* device, int inputIndex, const char*
     GParamSpec          *paramSpec;
     GstElement          *videosource;
     char                port_str[64];
-    char                *device_name = NULL;
     gchar               *pstring = NULL;
     gchar               *devString = NULL;
     psych_uint64        deviceURI = 0;
+
+    (void) flags;
 
     if (PsychPrefStateGet_Verbosity() > 5) {
         devString = gst_device_get_device_class(device);
@@ -959,11 +970,7 @@ static void PsychGSEnumerateVideoSourceType(const char* srcname, int classIndex,
     char                class_str[64];
     int                 inputIndex;
     GstElement          *videosource = NULL;
-    GValueArray         *viddevs = NULL;
-    GValue              *dev = NULL;
-    char                *device_name = NULL;
     gchar               *pstring = NULL;
-    psych_uint64        deviceURI = 0;
     int                 oldverbose;
 
     // Info to the user:
@@ -1181,11 +1188,6 @@ PsychVideosourceRecordType* PsychGSEnumerateVideoSources(int outPos, int deviceI
     const char *FieldNames[]={"DeviceIndex", "ClassIndex", "InputIndex", "ClassName", "InputHandle", "Device", "DevicePath", "DeviceName", "GUID", "DevicePlugin", "DeviceSelectorProperty" };
 
     int                 i;
-    GstElement          *videosource = NULL;
-    GValueArray         *viddevs = NULL;
-    GValue              *dev = NULL;
-    char                *device_name = NULL;
-    gchar               *pstring = NULL;
     PsychVideosourceRecordType *mydevice = NULL;
 
     // Make sure GStreamer is ready:
@@ -2818,11 +2820,9 @@ static GstPadProbeReturn PsychHaveVideoDataCallback(GstPad *pad, GstPadProbeInfo
     unsigned char *input_image;
     PsychVidcapRecordType *capdev = (PsychVidcapRecordType *) dataptr;
     GstBuffer *videoBuffer = info->data;
-    #pragma warning( disable : 4068 )
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     GstMapInfo mapinfo = GST_MAP_INFO_INIT;
-    #pragma GCC diagnostic pop
+
+    (void) pad;
 
     // Is a special markertracker plugin loaded for this camera? If so, execute it on this frame:
     if (capdev->markerTrackerPlugin) {
@@ -2880,8 +2880,6 @@ psych_bool PsychGSOpenVideoCaptureDevice(int slotid, PsychWindowRecordType *win,
     GstCaps         *colorcaps;
     GstCaps         *vfcaps, *reccaps;
     GstElement      *camera = NULL;
-    GMainLoop       *VideoContext = NULL;
-    GstBus          *bus = NULL;
     GstElement      *videosink = NULL;
     GstElement      *videosource = NULL;
     GstElement      *videosource_filter = NULL;
@@ -2911,6 +2909,8 @@ psych_bool PsychGSOpenVideoCaptureDevice(int slotid, PsychWindowRecordType *win,
     device_name[0] = 0;
     plugin_name[0] = 0;
     prop_name[0] = 0;
+
+    (void) allow_lowperf_fallback;
 
     // Init capturehandle to none:
     *capturehandle = -1;
@@ -4127,7 +4127,6 @@ int PsychGSDrainBufferQueue(PsychVidcapRecordType* capdev, int numFramesToDrain,
 int PsychGSVideoCaptureRate(int capturehandle, double capturerate, int dropframes, double* startattime)
 {
     GstElement              *camera = NULL;
-    GstBuffer               *videoBuffer = NULL;
     guint64                 nrInFrames, nrOutFrames, nrDroppedFrames, nrDuplicatedFrames;
     GstCaps                 *caps = NULL;
     GstCaps                 *capsi = NULL;
@@ -4138,7 +4137,6 @@ int PsychGSVideoCaptureRate(int capturehandle, double capturerate, int dropframe
     double                  fpsmin, fpsmax;
     int                     dropped = 0;
     int                     drainedCount;
-    float                   framerate = 0;
 
     // Retrieve device record for handle:
     PsychVidcapRecordType* capdev = PsychGetGSVidcapRecord(capturehandle);
@@ -4501,7 +4499,6 @@ int PsychGSGetTextureFromCapture(PsychWindowRecordType *win, int capturehandle, 
     PsychVidcapRecordType *capdev;
     GstBuffer *videoBuffer = NULL;
     GstSample *videoSample = NULL;
-    gint64 bufferIndex;
     double deltaT = 0;
     GstClockTime baseTime;
 
@@ -4511,18 +4508,13 @@ int PsychGSGetTextureFromCapture(PsychWindowRecordType *win, int capturehandle, 
     unsigned int count, i;
     unsigned char* pixptr;
     psych_uint16* pixptrs;
-    psych_bool newframe = FALSE;
     double tstart, tend;
     int nrdropped = 0;
     unsigned char* input_image = NULL;
 
-    // Disable warning about missing field initializer in calls
-    // like GstMapInfo mapinfo = = GST_MAP_INFO_INIT;
-    // Not our bug, but GStreamer's, so suppress for now.
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     GstMapInfo mapinfo = GST_MAP_INFO_INIT;
-    #pragma GCC diagnostic pop
+
+    (void) timeindex;
 
     // Make sure GStreamer is ready:
     PsychGSCheckInit("videocapture");
@@ -4729,8 +4721,6 @@ int PsychGSGetTextureFromCapture(PsychWindowRecordType *win, int capturehandle, 
             PsychProbeSampleProps(videoSample, NULL, NULL, &capdev->fps);
             printf("Bufferprobe: newfps = %f altfps = %f\n", capdev->fps, (float) ((deltaT > 0) ? 1.0 / deltaT : 0.0));
         }
-
-        bufferIndex = GST_BUFFER_OFFSET(videoBuffer);
     } else {
         if (PsychPrefStateGet_Verbosity()>0) printf("PTB-ERROR: No new video frame received in gst_app_sink_pull_sample! Something's wrong. Aborting fetch.\n");
         return(-1);
@@ -5015,7 +5005,6 @@ double PsychGSVideoCaptureSetParameter(int capturehandle, const char* pname, dou
     float oldfvalue = FLT_MAX;
     double oldvalue = DBL_MAX; // Initialize return value to the "unknown/unsupported" default.
     psych_bool assigned = false;
-    psych_bool present  = false;
     GstColorBalance* cb = NULL;
     GList* cl = NULL;
     GList* iter = NULL;

--- a/PsychSourceGL/Source/Common/Screen/PsychWindowSupport.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychWindowSupport.c
@@ -283,11 +283,9 @@ psych_bool PsychOpenOnscreenWindow(PsychScreenSettingsType *screenSettings, Psyc
     int logo_x, logo_y;
 
     CGDirectDisplayID cgDisplayID;
-    int attribcount=0;
     int ringTheBell=-1;
     GLint VRAMTotal=0;
     GLint TexmemTotal=0;
-    psych_bool multidisplay = FALSE;
     psych_bool sync_trouble = FALSE;
     psych_bool sync_disaster = FALSE;
     psych_bool did_pageflip = FALSE;
@@ -305,6 +303,8 @@ psych_bool PsychOpenOnscreenWindow(PsychScreenSettingsType *screenSettings, Psyc
     char splashPath[FILENAME_MAX];
     char* dummychar;
     FILE* splashFd;
+
+    (void) dummychar;
 
     // OS-9 emulation? If so, then we only work in double-buffer mode:
     if (PsychPrefStateGet_EmulateOldPTB()) numBuffers = 2;
@@ -3249,7 +3249,7 @@ psych_bool PsychFlipWindowBuffersIndirect(PsychWindowRecordType *windowRecord)
 */
 double PsychFlipWindowBuffers(PsychWindowRecordType *windowRecord, int multiflip, int vbl_synclevel, int dont_clear, double flipwhen, int* beamPosAtFlip, double* miss_estimate, double* time_at_flipend, double* time_at_onset)
 {
-    int screenheight, screenwidth;
+    int screenheight;
     GLint read_buffer, draw_buffer;
     unsigned char bufferstamp;
     const psych_bool vblsyncworkaround=false;  // Setting this to 'true' would enable some checking code. Leave it false by default.
@@ -3340,7 +3340,6 @@ double PsychFlipWindowBuffers(PsychWindowRecordType *windowRecord, int multiflip
 
     // Retrieve display id and screen size spec that is needed later...
     PsychGetCGDisplayIDFromScreenNumber(&displayID, windowRecord->screenNumber);
-    screenwidth=(int) PsychGetWidthFromRect(windowRecord->rect);
     screenheight=(int) PsychGetHeightFromRect(windowRecord->rect);
     vbl_startline = windowRecord->VBL_Startline;
 
@@ -6349,6 +6348,8 @@ int PsychRessourceCheckAndReminder(psych_bool displayMessage) {
  */
 int PsychGetCurrentShader(PsychWindowRecordType *windowRecord) {
     int curShader;
+
+    (void) windowRecord;
 
     if (GLEW_VERSION_2_0) {
         glGetIntegerv(GL_CURRENT_PROGRAM, &curShader);

--- a/PsychSourceGL/Source/Common/Screen/SCREENDrawDots.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENDrawDots.c
@@ -150,7 +150,7 @@ PsychError SCREENDrawDots(void)
     PsychWindowRecordType                   *windowRecord, *parentWindowRecord;
     int                                     m,n,p,mc,nc,idot_type;
     int                                     i, nrpoints, nrsize;
-    psych_bool                              isArgThere, usecolorvector, isdoublecolors, isuint8colors;
+    psych_bool                              isArgThere, usecolorvector;
     double                                  *xy, *size, *center, *dot_type, *colors;
     float                                   *sizef;
     unsigned char                           *bytecolors;
@@ -216,8 +216,6 @@ PsychError SCREENDrawDots(void)
     bytecolors = NULL;
 
     PsychPrepareRenderBatch(windowRecord, 2, &nrpoints, &xy, 4, &nc, &mc, &colors, &bytecolors, 3, &nrsize, &size, (GL_FLOAT == PsychGLFloatType(windowRecord)));
-    isdoublecolors = (colors) ? TRUE:FALSE;
-    isuint8colors  = (bytecolors) ? TRUE:FALSE;
     usecolorvector = (nc>1) ? TRUE:FALSE;
 
     // Assign sizef as float-type array of sizes, if float mode active, NULL otherwise:

--- a/PsychSourceGL/Source/Common/Screen/SCREENDrawLines.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENDrawLines.c
@@ -84,7 +84,7 @@ PsychError SCREENDrawLines(void)
     PsychWindowRecordType       *windowRecord;
     int                         m,n,p, smooth;
     int                         nrsize, nrvertices, mc, nc, i;
-    psych_bool                  isArgThere, usecolorvector, isdoublecolors, isuint8colors;
+    psych_bool                  isArgThere, usecolorvector;
     double                      *xy, *size, *center, *dot_type, *colors;
     unsigned char               *bytecolors;
     float                       linesizerange[2];
@@ -127,8 +127,6 @@ PsychError SCREENDrawLines(void)
     bytecolors = NULL;
 
     PsychPrepareRenderBatch(windowRecord, 2, &nrvertices, &xy, 4, &nc, &mc, &colors, &bytecolors, 3, &nrsize, &size, (GL_FLOAT == PsychGLFloatType(windowRecord)));
-    isdoublecolors = (colors) ? TRUE:FALSE;
-    isuint8colors  = (bytecolors) ? TRUE:FALSE;
     usecolorvector = (nc>1) ? TRUE:FALSE;
 
     // Assign sizef as float-type array of sizes, if float mode active, NULL otherwise:

--- a/PsychSourceGL/Source/Common/Screen/SCREENDrawText.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENDrawText.c
@@ -871,7 +871,7 @@ PsychError PsychOSDrawUnicodeText(PsychWindowRecordType* winRec, PsychRectType* 
 {
     char                *textString;
     unsigned int        i;
-    float               accumWidth, maxHeight, textHeightToBaseline, scalef;
+    float               accumWidth, maxHeight, textHeightToBaseline;
 
     #if PSYCH_SYSTEM == PSYCH_WINDOWS
         // Use GDI based text renderer on Windows, instead of display list based one?
@@ -879,6 +879,8 @@ PsychError PsychOSDrawUnicodeText(PsychWindowRecordType* winRec, PsychRectType* 
             // Call the GDI based renderer instead:
             return(PsychOSDrawUnicodeTextGDI(winRec, boundingbox, stringLengthChars, textUniDoubleString, xp, yp, yPositionIsBaseline, textColor, backgroundColor));
         }
+    #else
+        (void) backgroundColor;
     #endif
 
     // Malloc charstring and convert unicode string to char string:
@@ -904,8 +906,8 @@ PsychError PsychOSDrawUnicodeText(PsychWindowRecordType* winRec, PsychRectType* 
     accumWidth=0;
     maxHeight=0;
     for (i = 0; i < stringLengthChars; i++) {
-        accumWidth += winRec->textAttributes.glyphWidth[textString[i]];
-        maxHeight   = (winRec->textAttributes.glyphHeight[textString[i]] > maxHeight) ? winRec->textAttributes.glyphHeight[textString[i]] : maxHeight;
+        accumWidth += winRec->textAttributes.glyphWidth[(int) textString[i]];
+        maxHeight   = (winRec->textAttributes.glyphHeight[(int) textString[i]] > maxHeight) ? winRec->textAttributes.glyphHeight[(int) textString[i]] : maxHeight;
     }
 
     accumWidth *= (PSYCH_SYSTEM == PSYCH_WINDOWS) ? (float) winRec->textAttributes.textSize : 1.0f;

--- a/PsychSourceGL/Source/Common/Screen/SCREENFillPoly.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENFillPoly.c
@@ -68,14 +68,16 @@ void APIENTRY PsychtcbCombine(GLdouble c[3], void *d[4], GLfloat w[4], void **ou
 {
     GLdouble *nv;
 
-	// Free slots available?
-	if (combinerCacheSlot >= combinerCacheSize) {
-		// Nope. Need to alloc another cache for up to another 1000 elements:
-		combinerCacheSize = 1000;
-		combinerCacheSlot = 0;
-		combinerCache = (GLdouble *) PsychMallocTemp(sizeof(GLdouble) * 3 * combinerCacheSize);
-		if (NULL == combinerCache) PsychErrorExitMsg(PsychError_outofMemory, "Out of memory condition in Screen('FillPoly')! Not enough space.");
-	}
+    (void) d, (void) w;
+
+    // Free slots available?
+    if (combinerCacheSlot >= combinerCacheSize) {
+	    // Nope. Need to alloc another cache for up to another 1000 elements:
+	    combinerCacheSize = 1000;
+	    combinerCacheSlot = 0;
+	    combinerCache = (GLdouble *) PsychMallocTemp(sizeof(GLdouble) * 3 * combinerCacheSize);
+	    if (NULL == combinerCache) PsychErrorExitMsg(PsychError_outofMemory, "Out of memory condition in Screen('FillPoly')! Not enough space.");
+    }
 
     nv = (GLdouble *) &(combinerCache[combinerCacheSlot * 3]);
     nv[0] = c[0];

--- a/PsychSourceGL/Source/Common/Screen/SCREENGetFlipInfo.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENGetFlipInfo.c
@@ -57,8 +57,7 @@ PsychError SCREENGetFlipInfo(void)
 {
 #if PSYCH_SYSTEM == PSYCH_LINUX
     PsychWindowRecordType *windowRecord;
-    int infoType = 0, retIntArg;
-    double auxArg1, auxArg2, auxArg3;
+    int infoType = 0;
 #endif
 
     // All subfunctions should have these two lines.

--- a/PsychSourceGL/Source/Common/Screen/SCREENGetImage.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENGetImage.c
@@ -151,7 +151,7 @@ PsychError SCREENGetImage(void)
 {
     PsychRectType   windowRect, sampleRect;
     int             nrchannels, invertedY, stride;
-    size_t          ix, iy, sampleRectWidth, sampleRectHeight, redReturnIndex, greenReturnIndex, blueReturnIndex, alphaReturnIndex, planeSize;
+    size_t          ix, iy, sampleRectWidth, sampleRectHeight, redReturnIndex, greenReturnIndex, blueReturnIndex, alphaReturnIndex;
     int             viewid = 0;
     psych_uint8     *returnArrayBase, *redPlane;
     float           *dredPlane;
@@ -473,7 +473,6 @@ PsychError SCREENGetImage(void)
             else {
                 redPlane  = (psych_uint8*) PsychMallocTemp((size_t) nrchannels * sampleRectWidth * sampleRectHeight);
             }
-            planeSize = sampleRectWidth * sampleRectHeight;
 
             glPixelStorei(GL_PACK_ALIGNMENT,1);
             invertedY = (int) (windowRect[kPsychBottom] - sampleRect[kPsychBottom]);
@@ -531,7 +530,6 @@ PsychError SCREENGetImage(void)
                 dredPlane = (float*) PsychMallocTemp((size_t) nrchannels * sizeof(float) * sampleRectWidth * sampleRectHeight);
                 stride = nrchannels;
             }
-            planeSize = sampleRectWidth * sampleRectHeight * sizeof(float);
 
             glPixelStorei(GL_PACK_ALIGNMENT, 1);
             invertedY = (int) (windowRect[kPsychBottom]-sampleRect[kPsychBottom]);

--- a/PsychSourceGL/Source/Common/Screen/SCREENGetMouseHelper.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENGetMouseHelper.c
@@ -621,8 +621,6 @@ PsychError SCREENGetMouseHelper(void)
     double* buttonArray;
     PsychNativeBooleanType* buttonStates;
     int keysdown;
-    XEvent event_return;
-    XKeyPressedEvent keypressevent;
     int screenNumber;
     int priorityLevel;
     struct sched_param schedulingparam;
@@ -928,7 +926,7 @@ PsychError SCREENGetMouseHelper(void)
 
                 // Request current keyboard state from X-Server:
                 PsychLockDisplay();
-                XQueryKeymap(dpy, keys_return);
+                XQueryKeymap(dpy, (char *) keys_return);
                 PsychUnlockDisplay();
 
                 // Request current time of query:

--- a/PsychSourceGL/Source/Common/Screen/SCREENNull.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENNull.c
@@ -51,14 +51,11 @@ PsychError SCREENNull(void)
 //#define RADEON_R500_GEN_INT_CNTL   0x200
 //#define RADEON_R500_GEN_INT_STATUS 0x204
 
-	const double defaultMatrix[] = {1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4};
-	const double defaultM=2, defaultN=4; 
 	double tempValue; 
 	double *array;
-	int i, m,n, p, numInArgs, numOutArgs, numNamedOutArgs;
+	int i, m,n, p, numInArgs;
 	char *str;
 	PsychArgFormatType format;
-	PsychWindowRecordType *windowRecord;
 	const char defaultString[] = "I am the default string\n";
 
 	//all sub functions should have these two lines
@@ -84,7 +81,7 @@ PsychError SCREENNull(void)
 */
 
 		unsigned int regOffset, value, hi, lo;
-		PsychCopyInIntegerArg(1, TRUE, &regOffset);
+		PsychCopyInIntegerArg(1, TRUE, (int *) &regOffset);
 		value = PsychOSKDReadRegister(0, regOffset, NULL);
 
 		hi = value >> 16;
@@ -445,11 +442,11 @@ classToMatch = IOServiceNameMatching("ATIRadeonX1000");
 
 	//copy all the input argument to their outputs if we have doubles, if not error.  
 	numInArgs = PsychGetNumInputArgs();
-	numOutArgs = PsychGetNumOutputArgs();
-	numNamedOutArgs = PsychGetNumNamedOutputArgs();
 	PsychErrorExit(PsychCapNumOutputArgs(numInArgs));
 
 	/*
+	numOutArgs = PsychGetNumOutputArgs();
+	numNamedOutArgs = PsychGetNumNamedOutputArgs();
 	printf("number of input arguments: %d\n", numInArgs);
 	printf("number of output arguments: %d\n", numOutArgs);
 	printf("number of named output arguments: %d\n", numNamedOutArgs);

--- a/PsychSourceGL/Source/Common/Screen/SCREENResolutions.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENResolutions.c
@@ -151,7 +151,6 @@ PsychError SCREENConfigureDisplay(void)
 
         CGDirectDisplayID dpy;
         int screen;
-        float brightness;
         double nbrightness;
 
         // Map screenNumber and outputIdx to dpy, rootwindow and RandR output:

--- a/PsychSourceGL/Source/Common/Screen/SCREENTestTextureTwo.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENTestTextureTwo.c
@@ -15,8 +15,8 @@
   Accept one pointer to an offscreen window and one to an  onscreen window.  "Texturize" the contents of the offscreen window and copy them to the onscreen window.
 
   This is version two of TestTexture.  Herin we experiment with all of the ingredients necessary to impliment fast copy windows:
-	¥Client side texture storage
-	¥glCopyTexImage2D in conjunction with the above.
+	Client side texture storage
+	glCopyTexImage2D in conjunction with the above.
 	
   NOTES:
   
@@ -43,12 +43,12 @@
 
 #include "Screen.h"
 
-
-static char useString[] = "SCREEN('TestTexture', sourceWindowPntr, destWindowPntr, sourceWindowRect, destWindowRect);";
-static char synopsisString[] = 
-	"Test out textures for implementing  offscreen windows.";
-static char seeAlsoString[] = "";
-
+#if PSYCH_SYSTEM == PSYCH_OSX
+    static char useString[] = "SCREEN('TestTexture', sourceWindowPntr, destWindowPntr, sourceWindowRect, destWindowRect);";
+    static char synopsisString[] = 
+	    "Test out textures for implementing  offscreen windows.";
+    static char seeAlsoString[] = "";
+#endif
 
 PsychError SCREENTestTextureTwo(void) 
 {

--- a/PsychSourceGL/Source/Common/Screen/SCREENTextFont.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENTextFont.c
@@ -54,9 +54,10 @@ static char seeAlsoString[] = "";
 
 PsychError SCREENTextFont(void)
 {
-    psych_bool                  doSetByName, doSetByNumber, foundFont;
+    psych_bool                  doSetByName, doSetByNumber;
     PsychWindowRecordType       *windowRecord;
 #if PSYCH_SYSTEM == PSYCH_OSX
+    psych_bool foundFont = 0;
     PsychFontStructType         *fontRecord;
 #endif
     int                         oldTextFontNumber, inputTextFontNumber;
@@ -87,7 +88,6 @@ PsychError SCREENTextFont(void)
     PsychCheckInputArgType(2, kPsychArgOptional, PsychArgType_double | PsychArgType_char);  //if the argument is there check that it is the right type.
     doSetByNumber= PsychCopyInIntegerArg(2, kPsychArgAnything, &inputTextFontNumber);
     doSetByName= PsychAllocInCharArg(2, kPsychArgAnything, &inputTextFontName);
-    foundFont=0;
 #if PSYCH_SYSTEM == PSYCH_OSX
     if(doSetByNumber) {
         foundFont=PsychGetFontRecordFromFontNumber(inputTextFontNumber, &fontRecord);

--- a/PsychSourceGL/Source/Common/Screen/ScreenTypes.c
+++ b/PsychSourceGL/Source/Common/Screen/ScreenTypes.c
@@ -113,6 +113,7 @@ void PsychCopyDepthStruct(PsychDepthType *toDepth, PsychDepthType *fromDepth)
 */ 
 PsychColorModeType PsychGetColorModeFromDepthStruct(PsychDepthType *depth)
 {
+	(void) depth;
 	return(kPsychRGBAColor);
 }
 

--- a/PsychSourceGL/Source/Common/Screen/WindowHelpers.c
+++ b/PsychSourceGL/Source/Common/Screen/WindowHelpers.c
@@ -74,6 +74,7 @@ psych_bool PsychIsOnscreenWindow(PsychWindowRecordType *windowRecord)
 */
 psych_bool PsychIsMatlabOnscreenWindow(PsychWindowRecordType *windowRecord)
 {
+    (void) windowRecord;
     return(FALSE);
 }
 

--- a/PsychSourceGL/Source/Linux/Base/PsychTimeGlue.c
+++ b/PsychSourceGL/Source/Linux/Base/PsychTimeGlue.c
@@ -213,7 +213,7 @@ void PsychGetPrecisionTimerTicks(psych_uint64 *ticks)
 }
 
 void PsychGetPrecisionTimerTicksPerSecond(double *frequency)
-{struct timespec rqtp;
+{
   // MK: Ok, set this to 1 million. Our timesource is gettimeofday(), which
   // resolves time at microsecond resolution, so one can think of it as a
   // virtual timer with a tickrate of 1 Mhz
@@ -404,9 +404,8 @@ void PsychSetPrecisionTimerAdjustmentFactor(double *factor)
 */
 void PsychEstimateGetSecsValueAtTickCountZero(void)
 {
-  double		nowTicks, nowSecs;
-
   // MK: Todo - Implement GetTickCout().
+  // double nowTicks, nowSecs;
   // nowTicks=(double) GetTickCount();
   // PsychGetAdjustedPrecisionTimerSeconds(&nowSecs);
   // estimatedGetSecsValueAtTickCountZero=nowSecs - nowTicks * (1/1000.0f); 
@@ -477,7 +476,7 @@ int PsychUnlockMutex(psych_mutex* mutex)
 int PsychCreateThread(psych_thread* threadhandle, void* threadparams, void *(*start_routine)(void *), void *arg)
 {
 	// threadparams not yet used, this line just to make compiler happy:
-	(void*) threadparams;
+	(void) threadparams;
 	
 	// Return result code of pthread_create - We're a really thin wrapper around this Posix call:
 	return( pthread_create(threadhandle, NULL, start_routine, arg) );
@@ -504,7 +503,7 @@ int PsychAbortThread(psych_thread* threadhandle)
 void PsychTestCancelThread(psych_thread* threadhandle)
 {
 	// threadhandle unused on POSIX: This line just to make compiler happy:
-	(psych_thread*) threadhandle;
+	(void) threadhandle;
 	
 	// Test for cancellation, cancel if so:
 	pthread_testcancel();
@@ -703,6 +702,7 @@ int PsychTimedWaitCondition(psych_condition* condition, psych_mutex* mutex, doub
  */
 psych_uint64 PsychAutoLockThreadToCores(psych_uint64* curCpuMask)
 {
+    (void) curCpuMask;
     // No op on Linux.
     return(INT64_MAX);
 }

--- a/PsychSourceGL/Source/Linux/Screen/PsychScreenGlue.c
+++ b/PsychSourceGL/Source/Linux/Screen/PsychScreenGlue.c
@@ -108,6 +108,8 @@ static psych_bool isDCE11(int screenId)
 {
     psych_bool isDCE11 = false;
 
+    (void) screenId;
+
     // POLARIS10/11 are DCE11.2, but for our purpose we can so far
     // treat them as DCE11.0:
 
@@ -135,6 +137,8 @@ static psych_bool isDCE10(int screenId)
 {
     psych_bool isDCE10 = false;
 
+    (void) screenId;
+
     // TONGA and FIJI are DCE10 -- This is part of the "Volcanic Islands" GPU family.
 
     // TONGA: 0x692x - 0x693x so far.
@@ -154,6 +158,8 @@ static psych_bool isDCE10(int screenId)
 static psych_bool isDCE8(int screenId)
 {
     psych_bool isDCE8 = false;
+
+    (void) screenId;
 
     // Everything >= BONAIRE is DCE8 -- This is part of the "Sea Islands" GPU family.
 
@@ -186,6 +192,8 @@ static psych_bool isDCE64(int screenId)
 {
     psych_bool isDCE64 = false;
 
+    (void) screenId;
+
     // Everything == OLAND is DCE6.4 -- This is part of the "Southern Islands" GPU family.
 
     // OLAND in 0x66xx range:
@@ -198,6 +206,8 @@ static psych_bool isDCE64(int screenId)
 static psych_bool isDCE61(int screenId)
 {
     psych_bool isDCE61 = false;
+
+    (void) screenId;
 
     // Everything >= ARUBA which is an IGP is DCE6.1 -- This is the "Trinity" GPU family.
 
@@ -268,6 +278,8 @@ static psych_bool isDCE41(int screenId)
 {
     psych_bool isDCE41 = false;
 
+    (void) screenId;
+
     // Everything after PALM which is an IGP is DCE-4.1
     // Currently these are Palm, Sumo and Sumo2.
     // DCE-4.1 is a real subset of DCE-4, with all its
@@ -311,6 +323,8 @@ static psych_bool isDCE4(int screenId)
 static psych_bool isDCE3(int screenId)
 {
     psych_bool isDCE3 = false;
+
+    (void) screenId;
 
     // RV620, RV635, RS780, RS880, RV770, RV710, RV730, RV740,
     // aka roughly HD4330 - HD5165, HD5xxV, and some HD4000 parts.
@@ -1069,7 +1083,7 @@ psych_bool PsychCheckVideoSettings(PsychScreenSettingsType *setting)
 static void InitXInputExtensionForDisplay(CGDirectDisplayID dpy, int idx)
 {
     int major, minor;
-    int rc, i;
+    int rc;
 
     // XInputExtension supported? If so do basic init:
     if (!XQueryExtension(dpy, "XInputExtension", &xi_opcode, &xi_event, &xi_error)) {
@@ -1118,7 +1132,7 @@ static void ProcessRandREvents(int screenNumber)
 static void GetRandRScreenConfig(CGDirectDisplayID dpy, int idx)
 {
     int major, minor;
-    int o, m, num_crtcs, isPrimary, crtcid, crtccount;
+    int o, isPrimary, crtcid, crtccount;
     int primaryOutput = -1, primaryCRTC = -1, primaryCRTCIdx = -1;
     int crtcs[100];
 
@@ -1354,8 +1368,7 @@ const char* PsychOSGetOutputProps(int screenId, int outputIdx, unsigned long *mm
 
 void InitCGDisplayIDList(void)
 {
-    int major, minor;
-    int rc, i, j, k, count, scrnid;
+    int i, j, k, count, scrnid;
     char* ptbdisplays = NULL;
     char displayname[1000];
     CGDirectDisplayID x11_dpy = NULL;
@@ -1678,7 +1691,6 @@ double PsychOSVRefreshFromMode(XRRModeInfo *mode)
 int PsychGetAllSupportedScreenSettings(int screenNumber, int outputId, long** widths, long** heights, long** hz, long** bpp)
 {
     int i, j, o, nsizes, nrates, numPossibleModes;
-    XRRModeInfo *mode = NULL;
     XRROutputInfo *output_info = NULL;
 
     if(screenNumber >= numDisplays || screenNumber < 0) PsychErrorExit(PsychError_invalidScumber);
@@ -1972,6 +1984,8 @@ float PsychGetNominalFramerate(int screenNumber)
 // Error callback handler for X11 errors:
 static int x11VidModeErrorHandler(Display* dis, XErrorEvent* err)
 {
+    (void) dis;
+
     // If x11_errorbase not yet setup, simply return and ignore this error:
     if (x11_errorbase == 0) return(0);
 
@@ -1992,7 +2006,6 @@ float PsychSetNominalFramerate(int screenNumber, float requestedHz)
     // Information returned by/sent to the XF86VidModeExtension:
     XF86VidModeModeLine mode_line;  // The mode line of the current video mode.
     int dot_clock;                  // The RAMDAC / TDMS pixel clock frequency.
-    int rc;
     int event_base;
 
     // We start with a default vrefresh of zero, which means "couldn't query refresh from OS":
@@ -2161,6 +2174,8 @@ void PsychGetScreenRect(int screenNumber, double *rect)
 */
 int PsychGetDacBitsFromDisplay(int screenNumber)
 {
+    (void) screenNumber;
+
     return(8);
 }
 
@@ -2233,7 +2248,7 @@ int PsychOSSetOutputConfig(int screenNumber, int outputId, int newWidth, int new
 
         // Disable target crtc:
         if (PsychPrefStateGet_Verbosity() > 4) printf("PTB-INFO: Disabling crtc %i.\n", outputId);
-        Status rc = XRRSetCrtcConfig(dpy, res, res->crtcs[PsychScreenToHead(screenNumber, outputId)], crtc_info->timestamp,
+        XRRSetCrtcConfig(dpy, res, res->crtcs[PsychScreenToHead(screenNumber, outputId)], crtc_info->timestamp,
                                     0, 0, None, RR_Rotate_0, NULL, 0);
 
         // Resize screen: MK Don't! Skip this for now, use PsychSetScreenSettings() aka Screen('Resolution') to resize
@@ -2245,7 +2260,7 @@ int PsychOSSetOutputConfig(int screenNumber, int outputId, int newWidth, int new
         if (PsychPrefStateGet_Verbosity() > 4) printf("PTB-INFO: Enabling crtc %i.\n", outputId);
 
         crtc_info2 = XRRGetCrtcInfo(dpy, res, res->crtcs[PsychScreenToHead(screenNumber, outputId)]);
-        rc = XRRSetCrtcConfig(dpy, res, res->crtcs[PsychScreenToHead(screenNumber, outputId)], crtc_info2->timestamp,
+        XRRSetCrtcConfig(dpy, res, res->crtcs[PsychScreenToHead(screenNumber, outputId)], crtc_info2->timestamp,
                                 newX, newY, res->modes[modeid].id, crtc_info->rotation,
                                 crtc_info->outputs, crtc_info->noutput);
         XRRFreeCrtcInfo(crtc_info);
@@ -2291,6 +2306,8 @@ psych_bool PsychSetScreenSettings(psych_bool cacheSettings, PsychScreenSettingsT
     short           rate;
     Time            cfg_timestamp;
     CGDirectDisplayID dpy;
+
+    (void) cacheSettings;
 
     if (settings->screenNumber >= numDisplays || settings->screenNumber < 0) PsychErrorExitMsg(PsychError_internal, "screenNumber passed to PsychSetScreenSettings() is out of range");
     dpy = displayCGIDs[settings->screenNumber];
@@ -2945,6 +2962,8 @@ int PsychGetDisplayBeamPosition(CGDirectDisplayID cgDisplayId, int screenNumber)
     int vblbias, vbltotal;
     int beampos = -1;
 
+    (void) cgDisplayId;
+
     // Get beamposition from low-level driver code:
     if (PsychOSIsKernelDriverAvailable(screenNumber) && displayBeampositionHealthy[screenNumber]) {
         // Is application of the beamposition workaround requested by high-level code?
@@ -3028,6 +3047,8 @@ void PsychOSShutdownPsychtoolboxKernelDriverInterface(void)
 
 psych_bool PsychOSIsKernelDriverAvailable(int screenId)
 {
+    (void) screenId;
+
     // Currently our "kernel driver" is available if MMIO mem could be mapped:
     // A real driver would indicate its presence via numKernelDrivers > 0 (see init/teardown code just above this routine):
     return((gfx_cntl_mem) ? TRUE : FALSE);

--- a/PsychSourceGL/Source/Linux/Screen/PsychWindowGlue.c
+++ b/PsychSourceGL/Source/Linux/Screen/PsychWindowGlue.c
@@ -125,6 +125,8 @@ void PsychOSProcessEvents(PsychWindowRecordType *windowRecord, int flags)
     unsigned int depth_return, border_width_return, w, h;
     int x, y;
 
+    (void) flags;
+
     // Trigger event queue dispatch processing for GUI windows:
     if (windowRecord == NULL) {
         // No op, so far...
@@ -307,7 +309,7 @@ psych_bool PsychOSOpenOnscreenWindow(PsychScreenSettingsType *screenSettings, Ps
     psych_bool xfixes_available = FALSE;
     psych_bool newstyle_setup = FALSE;
     int gpuMaintype = 0;
-    unsigned char* mesaver = NULL;
+    const char* mesaver = NULL;
     psych_bool mesamapi_strdupbug = FALSE;
 
     // Include onscreen window index in title:
@@ -403,14 +405,14 @@ psych_bool PsychOSOpenOnscreenWindow(PsychScreenSettingsType *screenSettings, Ps
     glXQueryVersion(dpy, &major, &minor) && ((major > 1) || ((major == 1) && (minor >= 3))));
 
     // Initialize GLX-1.3 protocol support. Use if possible:
-    glXChooseFBConfig = (PFNGLXCHOOSEFBCONFIGPROC) glXGetProcAddressARB("glXChooseFBConfig");
-    glXGetFBConfigAttrib = (PFNGLXGETFBCONFIGATTRIBPROC) glXGetProcAddressARB("glXGetFBConfigAttrib");
-    glXGetVisualFromFBConfig = (PFNGLXGETVISUALFROMFBCONFIGPROC) glXGetProcAddressARB("glXGetVisualFromFBConfig");
-    glXCreateWindow = (PFNGLXCREATEWINDOWPROC) glXGetProcAddressARB("glXCreateWindow");
-    glXCreateNewContext = (PFNGLXCREATENEWCONTEXTPROC) glXGetProcAddressARB("glXCreateNewContext");
-    glXDestroyWindow = (PFNGLXDESTROYWINDOWPROC) glXGetProcAddressARB("glXDestroyWindow");
-    glXSelectEvent = (PFNGLXSELECTEVENTPROC) glXGetProcAddressARB("glXSelectEvent");
-    glXGetSelectedEvent = (PFNGLXGETSELECTEDEVENTPROC) glXGetProcAddressARB("glXGetSelectedEvent");
+    glXChooseFBConfig = (PFNGLXCHOOSEFBCONFIGPROC) glXGetProcAddressARB((const GLubyte *) "glXChooseFBConfig");
+    glXGetFBConfigAttrib = (PFNGLXGETFBCONFIGATTRIBPROC) glXGetProcAddressARB((const GLubyte *) "glXGetFBConfigAttrib");
+    glXGetVisualFromFBConfig = (PFNGLXGETVISUALFROMFBCONFIGPROC) glXGetProcAddressARB((const GLubyte *) "glXGetVisualFromFBConfig");
+    glXCreateWindow = (PFNGLXCREATEWINDOWPROC) glXGetProcAddressARB((const GLubyte *) "glXCreateWindow");
+    glXCreateNewContext = (PFNGLXCREATENEWCONTEXTPROC) glXGetProcAddressARB((const GLubyte *) "glXCreateNewContext");
+    glXDestroyWindow = (PFNGLXDESTROYWINDOWPROC) glXGetProcAddressARB((const GLubyte *) "glXDestroyWindow");
+    glXSelectEvent = (PFNGLXSELECTEVENTPROC) glXGetProcAddressARB((const GLubyte *) "glXSelectEvent");
+    glXGetSelectedEvent = (PFNGLXGETSELECTEDEVENTPROC) glXGetProcAddressARB((const GLubyte *) "glXGetSelectedEvent");
 
     PsychUnlockDisplay();
 
@@ -1236,10 +1238,10 @@ psych_bool PsychOSOpenOnscreenWindow(PsychScreenSettingsType *screenSettings, Ps
         // that actually uses the setup call -- no special cases or extra code needed there :-)
         // This special glXSwapIntervalSGI() call will simply accept an input value of zero for
         // disabling vsync'ed bufferswaps as a valid input parameter:
-        glXSwapIntervalSGI = (PFNGLXSWAPINTERVALSGIPROC) glXGetProcAddressARB("glXSwapIntervalMESA");
+        glXSwapIntervalSGI = (PFNGLXSWAPINTERVALSGIPROC) glXGetProcAddressARB((const GLubyte *) "glXSwapIntervalMESA");
 
         // Additionally bind the Mesa query call:
-        glXGetSwapIntervalMESA = (PFNGLXGETSWAPINTERVALMESAPROC) glXGetProcAddressARB("glXGetSwapIntervalMESA");
+        glXGetSwapIntervalMESA = (PFNGLXGETSWAPINTERVALMESAPROC) glXGetProcAddressARB((const GLubyte *) "glXGetSwapIntervalMESA");
         if (PsychPrefStateGet_Verbosity() > 3) printf("PTB-INFO: Using GLX_MESA_swap_control extension for control of vsync.\n");
     }
     else {
@@ -1250,14 +1252,14 @@ psych_bool PsychOSOpenOnscreenWindow(PsychScreenSettingsType *screenSettings, Ps
     // Special case: Buggy ATI driver: Supports the VSync extension and glXSwapIntervalSGI, but provides the
     // wrong extension namestring "WGL_EXT_swap_control" (from MS-Windows!), so GLEW doesn't auto-detect and
     // bind the extension. If this special case is present, we do it here manually ourselves:
-    if ((glXSwapIntervalSGI == NULL) && (strstr(glGetString(GL_EXTENSIONS), "WGL_EXT_swap_control") != NULL)) {
+    if ((glXSwapIntervalSGI == NULL) && (strstr((const char *) glGetString(GL_EXTENSIONS), "WGL_EXT_swap_control") != NULL)) {
         // Looks so: Bind manually...
-        glXSwapIntervalSGI = (PFNGLXSWAPINTERVALSGIPROC) glXGetProcAddressARB("glXSwapIntervalSGI");
+        glXSwapIntervalSGI = (PFNGLXSWAPINTERVALSGIPROC) glXGetProcAddressARB((const GLubyte *) "glXSwapIntervalSGI");
     }
 
     // Extension finally supported?
-    if (glXSwapIntervalSGI==NULL || ( strstr(glXQueryExtensionsString(dpy, scrnum), "GLX_SGI_swap_control")==NULL &&
-        strstr(glGetString(GL_EXTENSIONS), "WGL_EXT_swap_control")==NULL && strstr(glXQueryExtensionsString(dpy, scrnum), "GLX_MESA_swap_control")==NULL )) {
+    if (glXSwapIntervalSGI==NULL || ( strstr((const char *) glXQueryExtensionsString(dpy, scrnum), "GLX_SGI_swap_control")==NULL &&
+        strstr((const char *) glGetString(GL_EXTENSIONS), "WGL_EXT_swap_control")==NULL && strstr(glXQueryExtensionsString(dpy, scrnum), "GLX_MESA_swap_control")==NULL )) {
         // No, total failure to bind extension:
         glXSwapIntervalSGI = NULL;
 
@@ -1859,7 +1861,7 @@ void PsychOSInitializeOpenML(PsychWindowRecordType *windowRecord)
 
     // We check Linux versions 3.13 to 3.15 for broken kms-pageflip events if we are running on nouveau-kms.
     // Exceptions are -rc release candidate kernels, so MK can still use rc's built from git/source for patch testing.
-    if ((((major == 3) && ((minor >= 13) && (minor <= 15))) && !strstr(unameresult.release, "-rc")) && strstr(glGetString(GL_VENDOR), "nouveau")) {
+    if ((((major == 3) && ((minor >= 13) && (minor <= 15))) && !strstr(unameresult.release, "-rc")) && strstr((const char *) glGetString(GL_VENDOR), "nouveau")) {
         // Potentially faulty nouveau-kms. Check against the known kernel patchlevels when the bug was fixed:
         // We know Linux stable kernels 3.13.11.5+, 3.14.12+ and 3.15.5+ are fixed.
         // As far as Ubuntu distribution kernels go, we know the ones based on 3.13.11.5+ are fine,

--- a/PsychSourceGL/Source/Linux/Screen/PsychWindowTextGlue.c
+++ b/PsychSourceGL/Source/Linux/Screen/PsychWindowTextGlue.c
@@ -41,7 +41,6 @@ const PsychTextDrawingModeType PsychTextDrawingModes[]= {kPsychTextFill, kPsychT
 void PsychInitTextRecordSettings(PsychTextAttributes *settings)
 {
 	const char*	tryFontName;
-	psych_bool	foundFont;
 	// FIXME	PsychFontStructType	*initFontRecord;
 	PsychPrefStateGet_DefaultFontName(&tryFontName);
 
@@ -52,6 +51,7 @@ void PsychInitTextRecordSettings(PsychTextAttributes *settings)
 	settings->textStyle= PsychPrefStateGet_DefaultTextStyle();	// 0=normal,1=bold,2=italic,4=underline,8=outline,32=condense,64=extend	
 
 #ifdef COMMENTEDOUT
+	psych_bool	foundFont;
 	// FIXME!
 	/* to initialize the font record to coherent settings, we choose a default font and lookup the matching number */
 	foundFont=PsychGetFontRecordFromFontFamilyNameAndFontStyle(tryFontName, settings->textStyle, &initFontRecord);
@@ -78,6 +78,8 @@ void PsychInitTextRecordSettings(PsychTextAttributes *settings)
 void PsychGetTextDrawingModeNameFromTextDrawingModeConstant(char *modeNameStr, int modeNameStrSize, PsychTextDrawingModeType mode)
 {
     int i;
+
+    (void) modeNameStrSize;
     for(i=0; i<kPsychNumTextDrawingModes; i++){
         if(mode==PsychTextDrawingModes[i]){
             strncpy(modeNameStr, PsychTextDrawingModeNames[i], 255); 


### PR DESCRIPTION
Nothing ground breaking here.

You may have to take a look at the *GStreamer.c changes. Good news is that the "missing-field-initializers" warning for `GST_MAP_INFO_INIT` was fixed upstream. `videosinkCallbacks` had 4 function pointers in it, but `GstAppSinkCallbacks` defines 3 now, so I just culled the last of the one (which was a no-op).