### PR TITLE
Update PsychEyelinkDispatchCallback.m

### DIFF
--- a/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkBasic/PsychEyelinkDispatchCallback.m
+++ b/Psychtoolbox/PsychHardware/EyelinkToolbox/EyelinkBasic/PsychEyelinkDispatchCallback.m
@@ -130,7 +130,7 @@ end
 % Extract command code:
 eyecmd = callArgs(1);
 
-if isempty(3)
+if isempty(eyewin)
     warning('Got called as callback function from Eyelink() but usercode has not set a valid target onscreen window handle yet! Aborted.'); %#ok<WNTAG>
     return;
 end


### PR DESCRIPTION
The isempty(3) is a typo, I assume this wants to check if a PTB window is open before proceeding. Perhaps it should use `Screen(windowPtr, 'WindowKind')` but I'm not sure if this would add overhead to the callback, and checking if it is empty should do the same thing as the only place `eyewin` is set (line 112) that check has already been done.