### PR TITLE
Fix XOrgConfCreator.m: make sure strfind returns logical result

### DIFF
--- a/Psychtoolbox/PsychHardware/XOrgConfCreator.m
+++ b/Psychtoolbox/PsychHardware/XOrgConfCreator.m
@@ -603,11 +603,11 @@ function xdriver = DetectDDX(winfo)
     % Intel part -> intel ddx:
     fprintf('Intel GPU detected. ');
     xdriver = 'intel';
-  elseif strfind(winfo.DisplayCoreId, 'NVidia') && strfind(winfo.GLVendor, 'nouveau')
+  elseif ~isempty(strfind(winfo.DisplayCoreId, 'NVidia')) && ~isempty(strfind(winfo.GLVendor, 'nouveau'))
     % NVidia part under nouveau -> nouveau ddx:
     fprintf('Nvidia GPU with open-source driver detected. ');
     xdriver = 'nouveau';
-  elseif strfind(winfo.DisplayCoreId, 'NVidia') && strfind(winfo.GLVendor, 'NVIDIA')
+  elseif ~isempty(strfind(winfo.DisplayCoreId, 'NVidia')) && ~isempty(strfind(winfo.GLVendor, 'NVIDIA'))
     % NVidia part under binary blob -> nvidia ddx:
     fprintf('Nvidia GPU with proprietary driver detected. ');
     xdriver = 'nvidia';


### PR DESCRIPTION
XOrgConfCreator fails on my machine due to the fact it uses && logic with strfind, but strfind does not return logical values. One can either use & to bypass the logical requirement or wrap strfind using ~isempty() which I did here...