### PR TITLE
Fix segfault after PsychPortAudio starts Master Capture device

### DIFF
--- a/PsychSourceGL/Source/Common/PsychPortAudio/PsychPortAudio.c
+++ b/PsychSourceGL/Source/Common/PsychPortAudio/PsychPortAudio.c
@@ -1177,8 +1177,10 @@ static int paCallback( const void *inputBuffer, void *outputBuffer,
             }
         }
 
-        // Have scratch buffers ready. Clear output intermix buffer:
-        memset(outputBuffer, 0, (size_t) (dev->batchsize * outchannels * sizeof(float)));
+        if (NULL != outputBuffer) {
+            // Have scratch buffers ready. Clear output intermix buffer:
+            memset(outputBuffer, 0, (size_t) (dev->batchsize * outchannels * sizeof(float)));
+        }
 
         // Iterate over all slave device callbacks: Or at least until all registered slaves are handled.
         numSlavesHandled = 0;


### PR DESCRIPTION
Master code was writing to outputBuffer without checking it first. Check for NULL pointer before writing to outputBuffer in master control logic within paCallback.