### PR TITLE
ProceduralSmoothedDiscs per-disc alpha parameter added

### DIFF
--- a/Psychtoolbox/PsychDemos/Contents.m
+++ b/Psychtoolbox/PsychDemos/Contents.m
@@ -88,6 +88,7 @@
 %    ProceduralSquareWaveDemo - Demo for fast drawing of square wave grating.
 %    ProceduralSmoothedApertureSineGratingDemo - Demo for fast drawing of smoothed aperture sine grating.
 %    ProceduralSmoothedDiscsDemo - Demo for fast drawing of smoothed aperture discs.
+%    ProceduralSmoothedDiscMaskDemo - Demo for fast drawing of smoothed aperture disc used as a mask.
 %    PsychRTBoxDemo          - Demonstrates basic use of the RTBox reaction time button response box.
 %    RaspberryPiGPIODemo     - Show basic use of GPIO's on a RaspberryPi running Raspian GNU/Linux.
 %    ReceivingTriggerFromSerialPortDemo - Template for asynchronous trigger collection and timestamping from serial port.

--- a/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscMaskDemo.m
+++ b/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscMaskDemo.m
@@ -1,13 +1,13 @@
 function ProceduralSmoothedDiscMaskDemo(ndiscs)
-% ProceduralSmoothedDiscMaskDemo([ndiscs=700]) -- An aquarium full of discs!
+% ProceduralSmoothedDiscMaskDemo([ndiscs=700]) -- An aquarium full of discs 
+% within a centered mask!
 %
 % This demo shows how to use the Screen('DrawTextures') command to draw a
 % large number of similar images quickly - in this case, smooth edged
-% discs.
+% discs masked by another smoothed disc.
 
 % History:
-% 12/12/2017 modified from ProceduralGarboriumDemo (Ian Andolina)
-% 24/04/2018 add per-disc alpha parameter to demo (Junxiang Luo & Ian Andolina)
+% 25/04/2018 created (Junxiang Luo)
 
 % Setup defaults and unit color range:
 PsychDefaultSetup(2);

--- a/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscMaskDemo.m
+++ b/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscMaskDemo.m
@@ -1,6 +1,6 @@
 function ProceduralSmoothedDiscMaskDemo(ndiscs)
-% ProceduralSmoothedDiscMaskDemo([ndiscs=700]) -- An aquarium full of discs 
-% within a centered mask!
+% ProceduralSmoothedDiscMaskDemo([ndiscs=700]) -- An aquarium full of discs
+% within a centered mask.
 %
 % This demo shows how to use the Screen('DrawTextures') command to draw a
 % large number of similar images quickly - in this case, smooth edged
@@ -15,7 +15,7 @@ PsychDefaultSetup(2);
 % Disable synctests for this quick demo:
 oldSyncLevel = Screen('Preference', 'SkipSyncTests', 2);
 
-% Set number of gabor patches to 400 if no number provided:
+% Set number of discs to 700 if no number provided:
 if nargin < 1 || isempty(ndiscs)
     ndiscs = 700;
 end
@@ -23,14 +23,13 @@ end
 randSizeFlag = 1;
 maskFlag = 1;
 
+% open our screen
 PsychImaging('PrepareConfiguration');
 PsychImaging('AddTask', 'General', 'FloatingPoint32BitIfPossible');
-
 screenid = max(Screen('Screens'));
-[win, winRect] = PsychImaging('OpenWindow', screenid, 0.5);
-[w, h] = RectSize(winRect);
-
-Screen('BlendFunction', win, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); 
+[win, winRect] = PsychImaging('OpenWindow', screenid, 0);
+[width, height] = RectSize(winRect);
+Screen('BlendFunction', win, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 % dot parameters
 dotRadius = 5;
@@ -42,22 +41,20 @@ useAlpha = true;
 dotMethod = 1;
 
 %mask parameters
-maskRadius = h/4;
+maskRadius = height/2;
 maskSigma = maskRadius;
 % smoothing method: cosine (0), smoothstep (1), inverse smoothstep (2)
 maskMethod = 2;
 
+% create our procedural textures
 [dotstex, dotsrect] = CreateProceduralSmoothedDisc(win,...
-	dotSize, dotSize, [], dotRadius, dotSigma, useAlpha, dotMethod);
+    dotSize, dotSize, [], dotRadius, dotSigma, useAlpha, dotMethod);
 
 [masktex, maskrect] = CreateProceduralSmoothedDisc(win,...
-	w, h, [], maskRadius, maskSigma, useAlpha, maskMethod);
+    width, height, [], maskRadius, maskSigma, useAlpha, maskMethod);
 
-mydots = repmat([0, 0, 0, 0]', 1, ndiscs);
-mymask = [1, 0, 0, 0]';
-
+% create our positions on screen
 inrect = repmat(dotsrect', 1, ndiscs);
-
 dotDstRects = zeros(4, ndiscs);
 scale = zeros(1,ndiscs);
 for i=1:ndiscs
@@ -66,42 +63,52 @@ for i=1:ndiscs
     else
         scale(i) = 1;
     end
-    dotDstRects(:, i) = CenterRectOnPointd(dotsrect * scale(i), rand * w, rand * h)';
+    dotDstRects(:, i) = CenterRectOnPointd(dotsrect * scale(i), rand * width, rand * height)';
 end
+maskDstRects = CenterRectOnPointd(maskrect, width/2, height/2)';
 
-maskDstRects = CenterRectOnPointd(maskrect, w/2, h/2)';
-
-count = 0;
-randAlpha = rand(1, ndiscs);
-mydots(1,:) = randAlpha;
+% the rotation angles for each disc
 rotAngles = rand(1, ndiscs) * 360;
 
-ifi = Screen('GetFlipInterval', win);
+% create random alphas for yellow discs
+colours = repmat([1 1 0 1]',1,ndiscs);
+colours(4,:) = rand(ndiscs,1)';
+myAlphas = colours(4,:);
+
+% Initially sync us to VBL at start of animation loop.
+count = 0;
 vbl = Screen('Flip', win);
+tstart = vbl;
 
 while ~KbCheck
-    Screen('DrawTextures', win, dotstex, [], dotDstRects, rotAngles, [], 1, [1, 1, 0, 1]', [], [], mydots);
+    % Screen('DrawTextures', windowPointer, texturePointer(s) [, sourceRect(s)]
+    %[, destinationRect(s)] [, rotationAngle(s)] [, filterMode(s)] [, globalAlpha(s)]
+    %[, modulateColor(s)] [, textureShader] [, specialFlags] [, auxParameters]);
+    Screen('DrawTextures', win, dotstex, [], dotDstRects, rotAngles, [], [], colours, [], []);
     
     if maskFlag
-        Screen('DrawTextures', win, masktex, [], maskDstRects, [], [], 1, [0.5, 0.5, 0.5, 1]', [], [], mymask);
+        Screen('DrawTextures', win, masktex, [], maskDstRects, [], [], 1, [0, 0, 0, 1]', [], []);
     end
-   
+    
     Screen('DrawingFinished', win);
-   
-    rotAngles = rotAngles + 5 * randn(1, ndiscs);  
-    mydots(1,:) = (1+sin(randAlpha*100-200 + count*0.05))/2;
-   
+    
+    rotAngles = rotAngles + 5 * randn(1, ndiscs);
+    colours(4,:) = (1+sin(myAlphas*100-200 + count*0.05))/2;
+    
     [x, y] = RectCenterd(dotDstRects);
-    x = mod(x + 0.5 * cos(rotAngles/360*2*pi), w);
-    y = mod(y - 0.5 * sin(rotAngles/360*2*pi), h);
-   
+    x = mod(x + 0.5 * cos(rotAngles/360*2*pi), width);
+    y = mod(y - 0.5 * sin(rotAngles/360*2*pi), height);
+    
     dotDstRects = CenterRectOnPointd(inrect .* repmat(scale,4,1), x, y);
-   
-    vbl = Screen('Flip', win, vbl + 0.5*ifi);
-	
-	count = count + 1;
+    
+    Screen('Flip', win);
+    
+    count = count + 1;
 end
 
-vbl = Screen('Flip', win);
+Screen('Flip', win);
 
 sca;
+
+% Restore old settings for sync-tests:
+Screen('Preference', 'SkipSyncTests', oldSyncLevel);

--- a/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscMaskDemo.m
+++ b/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscMaskDemo.m
@@ -1,0 +1,107 @@
+function ProceduralSmoothedDiscMaskDemo(ndiscs)
+% ProceduralSmoothedDiscMaskDemo([ndiscs=700]) -- An aquarium full of discs!
+%
+% This demo shows how to use the Screen('DrawTextures') command to draw a
+% large number of similar images quickly - in this case, smooth edged
+% discs.
+
+% History:
+% 12/12/2017 modified from ProceduralGarboriumDemo (Ian Andolina)
+% 24/04/2018 add per-disc alpha parameter to demo (Junxiang Luo & Ian Andolina)
+
+% Setup defaults and unit color range:
+PsychDefaultSetup(2);
+
+% Disable synctests for this quick demo:
+oldSyncLevel = Screen('Preference', 'SkipSyncTests', 2);
+
+% Set number of gabor patches to 400 if no number provided:
+if nargin < 1 || isempty(ndiscs)
+    ndiscs = 700;
+end
+
+randSizeFlag = 1;
+maskFlag = 1;
+
+PsychImaging('PrepareConfiguration');
+PsychImaging('AddTask', 'General', 'FloatingPoint32BitIfPossible');
+
+screenid = max(Screen('Screens'));
+[win, winRect] = PsychImaging('OpenWindow', screenid, 0.5);
+[w, h] = RectSize(winRect);
+
+Screen('BlendFunction', win, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); 
+
+% dot parameters
+dotRadius = 5;
+dotSize = 2*dotRadius+1;
+dotSigma = 5;
+% use alpha channel for smoothing edge of disc?
+useAlpha = true;
+% smoothing method: cosine (0), smoothstep (1), inverse smoothstep (2)
+dotMethod = 1;
+
+%mask parameters
+maskRadius = h/4;
+maskSigma = maskRadius;
+% smoothing method: cosine (0), smoothstep (1), inverse smoothstep (2)
+maskMethod = 2;
+
+[dotstex, dotsrect] = CreateProceduralSmoothedDisc(win,...
+	dotSize, dotSize, [], dotRadius, dotSigma, useAlpha, dotMethod);
+
+[masktex, maskrect] = CreateProceduralSmoothedDisc(win,...
+	w, h, [], maskRadius, maskSigma, useAlpha, maskMethod);
+
+mydots = repmat([0, 0, 0, 0]', 1, ndiscs);
+mymask = [1, 0, 0, 0]';
+
+inrect = repmat(dotsrect', 1, ndiscs);
+
+dotDstRects = zeros(4, ndiscs);
+scale = zeros(1,ndiscs);
+for i=1:ndiscs
+    if randSizeFlag
+        scale(i) = 1*(0.1 + 0.9 * randn);
+    else
+        scale(i) = 1;
+    end
+    dotDstRects(:, i) = CenterRectOnPointd(dotsrect * scale(i), rand * w, rand * h)';
+end
+
+maskDstRects = CenterRectOnPointd(maskrect, w/2, h/2)';
+
+count = 0;
+randAlpha = rand(1, ndiscs);
+mydots(1,:) = randAlpha;
+rotAngles = rand(1, ndiscs) * 360;
+
+ifi = Screen('GetFlipInterval', win);
+vbl = Screen('Flip', win);
+
+while ~KbCheck
+    Screen('DrawTextures', win, dotstex, [], dotDstRects, rotAngles, [], 1, [1, 1, 0, 1]', [], [], mydots);
+    
+    if maskFlag
+        Screen('DrawTextures', win, masktex, [], maskDstRects, [], [], 1, [0.5, 0.5, 0.5, 1]', [], [], mymask);
+    end
+   
+    Screen('DrawingFinished', win);
+   
+    rotAngles = rotAngles + 5 * randn(1, ndiscs);  
+    mydots(1,:) = (1+sin(randAlpha*100-200 + count*0.05))/2;
+   
+    [x, y] = RectCenterd(dotDstRects);
+    x = mod(x + 0.5 * cos(rotAngles/360*2*pi), w);
+    y = mod(y - 0.5 * sin(rotAngles/360*2*pi), h);
+   
+    dotDstRects = CenterRectOnPointd(inrect .* repmat(scale,4,1), x, y);
+   
+    vbl = Screen('Flip', win, vbl + 0.5*ifi);
+	
+	count = count + 1;
+end
+
+vbl = Screen('Flip', win);
+
+sca;

--- a/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscsDemo.m
+++ b/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscsDemo.m
@@ -117,7 +117,10 @@ while ~KbCheck
     % speed by the speed of your main processor.
 	
 	% compute a new per disc alpha
-	discParamaters(1,:) = (1+sin(myAlphas*100-200 + count*0.1))/2;
+	discParamaters(1,:) = (1+sin(myAlphas*100-200 + count*0.05))/2;
+	
+	% change the direction slightly
+	rotAngles = rotAngles + 5 * randn(1, ndiscs);  
 
     % Compute centers of all patches, then shift them in new direction of
     % motion 'rotAngles', use the mod() operator to make sure they don't

--- a/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscsDemo.m
+++ b/Psychtoolbox/PsychDemos/ProceduralSmoothedDiscsDemo.m
@@ -7,6 +7,7 @@ function ProceduralSmoothedDiscsDemo(ndiscs)
 
 % History:
 % 12/12/2017 modified from ProceduralGarboriumDemo (Ian Andolina)
+% 24/04/2018 add per-disc alpha parameter to demo (Junxiang Luo & Ian Andolina)
 
 % Setup defaults and unit color range:
 PsychDefaultSetup(2);

--- a/Psychtoolbox/PsychGLImageProcessing/CreateProceduralSmoothedDisc.m
+++ b/Psychtoolbox/PsychGLImageProcessing/CreateProceduralSmoothedDisc.m
@@ -6,6 +6,7 @@ function [discid, discrect] = CreateProceduralSmoothedDisc(windowPtr, width, hei
 % in a very fast and efficient manner on modern graphics hardware.
 %
 % 'windowPtr' A handle to the onscreen window.
+%
 % 'width' x 'height' The maximum size (in pixels) of the grating. More
 % precise, the size of the mathematical support of the grating. Providing too
 % small values here would 'cut off' peripheral parts or your grating. Too big
@@ -23,7 +24,9 @@ function [discid, discrect] = CreateProceduralSmoothedDisc(windowPtr, width, hei
 %
 % 'useAlpha' whether to use colour (0) or alpha (1) for smoothing channel
 %
-% 'method' whether to use cosine (0) or smoothstep (1) smoothing function
+% 'method' whether to use cosine (0) or smoothstep (1) functions. If you
+%  pass (2) then the smoothstep will be inverted, so you can use it as a
+%  mask (see ProceduralSmoothedDiscMaskDemo.m for example).
 %
 % The function returns a procedural texture handle that you can
 % pass to the Screen('DrawTexture(s)', windowPtr, id, ...) functions

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.frag.txt
@@ -18,6 +18,7 @@ float Dist;
 float Mod;
 
 varying vec4 baseColor;
+varying float discAlpha;
 
 void main()
 {
@@ -48,6 +49,6 @@ void main()
     }
     else {
         gl_FragColor.rgb = baseColor.rgb;
-        gl_FragColor.a = Mod;
+        gl_FragColor.a = baseColor.a*Mod*discAlpha;
     }
 }

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.frag.txt
@@ -31,7 +31,7 @@ void main()
     /* and only do this if we do not invert the alpha mask (Method == 2.0)
     if (Method < 2.0) {
         if (Dist > Radius) discard;
-    end
+    }
 
     /* Calculate a smoothing modifier using our distance from radius and a Sigma */
     if (Method < 1.0) {

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.frag.txt
@@ -18,7 +18,6 @@ float Dist;
 float Mod;
 
 varying vec4 baseColor;
-varying float discAlpha;
 
 void main()
 {
@@ -28,8 +27,11 @@ void main()
     /* find our distance from center */
     Dist = distance(pos, Center);
 
-    /* If distance to center (aka radius of pixel) > Radius, discard this pixel: */
-    /*if (Dist > Radius) discard;*/
+    /* If distance to center (aka radius of pixel) > Radius, discard this pixel */
+    /* and only do this if we do not invert the alpha mask (Method == 2.0)
+    if (Method < 2.0) {
+        if (Dist > Radius) discard;
+    end
 
     /* Calculate a smoothing modifier using our distance from radius and a Sigma */
     if (Method < 1.0) {
@@ -54,6 +56,6 @@ void main()
     }
     else {
         gl_FragColor.rgb = baseColor.rgb;
-        gl_FragColor.a = baseColor.a*Mod*discAlpha;
+        gl_FragColor.a = baseColor.a * Mod;
     }
 }

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.frag.txt
@@ -29,7 +29,7 @@ void main()
     Dist = distance(pos, Center);
 
     /* If distance to center (aka radius of pixel) > Radius, discard this pixel: */
-    if (Dist > Radius) discard;
+    /*if (Dist > Radius) discard;*/
 
     /* Calculate a smoothing modifier using our distance from radius and a Sigma */
     if (Method < 1.0) {
@@ -37,8 +37,13 @@ void main()
         Mod = clamp(Mod, 0.0, 1.0);
         Mod = cos(Mod * halfpi);
     }
-    else {
+    else if (Method == 1.0) {
         Mod = smoothstep(Radius,(Radius-Sigma),Dist);
+    }
+    /*we use smoothstep but invert our alpha so we can use the disc as a mask */
+    else if (Method == 2.0) {
+        Mod = smoothstep(Radius,(Radius-Sigma),Dist);
+        Mod = 1.0 - Mod;
     }
 
     /* Multiply/Modulate base color and alpha with calculated sine          */

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.vert.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.vert.txt
@@ -16,11 +16,9 @@
 
 /* Attributes passed from Screen(): See the ProceduralShadingAPI.m file for infos: */
 attribute vec4 modulateColor;
-attribute vec4 auxParameters0;
 
 /* Information passed to the fragment shader: Attributes and precalculated per patch constants: */
 varying vec4 baseColor;
-varying float discAlpha;
 
 void main()
 {
@@ -32,7 +30,4 @@ void main()
     
     /* Premultiply the wanted Contrast to the color: */
     baseColor = modulateColor;
-
-    /* The total alpha value passed from DrawTextures */
-    discAlpha = auxParameters0[0];
 }

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.vert.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SmoothedDiscShader.vert.txt
@@ -20,6 +20,7 @@ attribute vec4 auxParameters0;
 
 /* Information passed to the fragment shader: Attributes and precalculated per patch constants: */
 varying vec4 baseColor;
+varying float discAlpha;
 
 void main()
 {
@@ -31,4 +32,7 @@ void main()
     
     /* Premultiply the wanted Contrast to the color: */
     baseColor = modulateColor;
+
+    /* The total alpha value passed from DrawTextures */
+    discAlpha = auxParameters0[0];
 }


### PR DESCRIPTION
This commit just allow a user to pass an alpha value per disc when using DrawTextures. Update the demo to "pulse" the alpha values for each disc. A few doc fixes and use ~KbCheck instead of fixed timer.