### PR TITLE
Code to help migrate Psychtoolbox help onto GitHub Wiki

### DIFF
--- a/managementtools/PTB-wikify-into-files.py
+++ b/managementtools/PTB-wikify-into-files.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2008 Tobias Wolf <towolf@tuebingen.mpg.de>
+#
+# Copyright (C) 2018 Justin Ales <justin.ales@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+"""
+PTB-wikify-into-files.py: Extract help strings in .m-files and write help into files
+Supports markdown and mediawiki outputs.
+
+Usage: PTB-wikify-into-files.py [options] ([m-files]|[directory])
+
+Options:
+ -h, --help
+ -o [dir], --output-dir     Output directory to write files into.
+ -f [format], --format    Output file format, can be either markdown, or mediawiki
+ -r,  --recursive         recursive mode: use only with a single directory
+ -m,  --mexmode           mex mode: also look for .mexmaci files and post their
+                            help strings by calling MATLAB and running them
+                            In recursive mode both M and Mex files are posted.
+                            (edit the source to change _mexext into one of
+                             .mexglx, .mexmaci, or .dll)
+ -v                       be verbose (massive text output)
+                            this prints out:
+                              - which files were skipped
+                              - a diff of the text before submission
+
+
+This script is designed to work with a GitHub wiki.  GitHub exposes its wiki as
+git repository with each page corresponding to a file.  This script will write
+out all files into a directory that can be pushed into the wiki repository to
+update the wiki.
+
+Examples:
+
+This is currently kind of tricky to use because care must be taken with the 2
+separate git repositories, the wiki and the code. The script should be run from
+the Psychtoolbox root directory and give an path to an output directory outside
+the psychtoolbox directory.
+
+Example to, Clone the wiki, than extract files from PsychBasic,
+than push changes back onto wiki:
+
+  cd ~/git
+  git clone https://github.com/Psychtoolbox-3/Psychtoolbox-3.wiki.git
+  cd /path/to/psychtoolbox
+  PTB-wikify-into-files.py -m -o ~/Psychtoolbox-3.wiki/ PsychBasic/*.m
+
+  cd ~/git/Psychtoolbox-3.wiki
+  git add -A
+  git commit -m "Update Message"
+  git push
+
+ALternatively recursively add all files in the directory:
+  PTB-wikify-into-files.py -r -m -o ~/git/Psychtoolbox-3.wiki/ PsychBasic/
+
+Example script that outputs entire PTB tree:
+cd /path/to/Psychtoolbox
+../managementtools/PTB-wikify-into-files.py -m -o /Users/ales/git/Psychtoolbox-3-aleslab-fork.wiki *.m;
+#Exclude PsychOpenGL because it has 2700+ files and overloads github wiki.
+for name in `find * -maxdepth 0 -type d -not -name PsychOpenGL`;
+do
+../managementtools/PTB-wikify-into-files.py -rm -o /Users/ales/git/Psychtoolbox-3-aleslab-fork.wiki $name;
+done
+#Just extract documentation from the base PsychOpenGL folder
+../managementtools/PTB-wikify-into-files.py -m -o /Users/ales/git/Psychtoolbox-3-aleslab-fork.wiki PsychOpenGL/*.m*;
+
+ for name in `find * -maxdepth 0 -type d -not -name PsychOpenGL`; do  ../managementtools/PTB-wikify-into-files.py -o /Users/ales/git/Psychtoolbox-3-aleslab-fork.wiki -rm $name; done
+IMPORTANT!!:
+  Always change your working directory to the root of the
+  tree before running the script, e.g.,
+    cd Psychtoolbox
+    ~/PTB-wikify-into-files.py -r PsychDemos/PsychExampleExperiments
+
+   (This is to figure out what the root node is supposed to be.)
+
+"""
+
+import sys, os, re, subprocess
+import getopt
+
+#from urllib2 import HTTPError
+
+#import mechanize
+#assert mechanize.__version__ >= (0, 0, 6, "a")
+
+import textwrap
+
+#from  BeautifulSoup import BeautifulSoup, Tag, NavigableString
+
+#mechanical soup is the python3 update for mechanize and beautifulsoup
+#import mechanicalsoup
+
+#baseurl = "http://docs.psychtoolbox.org/wikka.php?wakka="
+outputdir = "./"
+username = "DocBot"
+password = ""
+_recursive = 0
+_mexmode = 0
+outputFormat = "markdown"
+
+from sys import platform
+if platform == "linux" or platform == "linux2":
+    # linux
+    _mexext = '.mexa64'
+elif platform == "darwin":
+    # OS X
+    _mexext = '.mexmaci64'
+elif platform == "win32":
+    # Windows...
+    _mexext = '.mexmw64'
+
+_debug = 0
+_fulldiff = 0
+
+# This version writes files instead of directly posting onto website.
+# global mech
+# mech = mechanicalsoup.Browser()
+
+def parse(filename):
+    '''Parse helpful initial comment block from .m-file'''
+    docstring = []
+    functionellipsized = False
+    for line in open(filename,'r',newline=None):
+        # weird hack
+        if line.strip()[0:8] + line.strip()[-3:] == 'function...':
+            functionellipsized = True
+        if line.strip().startswith('%'):       # get comment lines
+            docstring.append(line)
+        elif len(docstring): break             # and stop after one block
+            # we allow empty lines and the function def before the block
+        elif len(line.strip()) > 0 \
+                and not line.strip().startswith('function')\
+                and not functionellipsized: break
+
+    # strip first two chars: '% '
+    return textwrap.dedent(''.join([l[1:] for l in docstring]))
+
+def beackern(mkstring):
+    '''Regex cleaning of PTB docstrings'''
+    # expand tabs to four spaces
+    mkstring = mkstring.expandtabs(4)
+    # Enclose text markup characters with: ""
+#    mkstring = re.sub(r'(\+\+|(--){2}\b|==|\'\'|@@|[^:]//|>>|<<|##)',r'""\1""',mkstring)
+    # escape markdown characters with \
+    mkstring = re.sub(r'(#|\*|_|>)',r'\\\1',mkstring)
+
+#Double new lines for to break lines for markdown.
+#    mkstring = re.sub(r'(\n)',r'\n\n',mkstring)
+
+    # Replace 'Windows: ______' with headline
+    mkstring = re.sub(r'(?m)^(.*):\s*[_-]{3,}',r'# \1',mkstring)
+    # Replace long _______ with ---- i.e.<HR>
+    mkstring = re.sub(r'(?m)^\s*_{10,}',r'----',mkstring)
+    # Replace some non-WikiWord function to internal links
+    match = r'(\bScreen\b|' \
+            + r'\bAsk\b|' \
+            + r'\bBandpass\b|' \
+            + r'\bBeeper\b|' \
+            + r'\bCircle\b|' \
+            + r'\bClose\b|' \
+            + r'\bComputeDKL_M\b|' \
+            + r'\bDKLDemo\b|' \
+            + r'\bEllipse\b|' \
+            + r'\bExpand\b|' \
+            + r'\bExplode\b|' \
+            + r'\bFlip\b|' \
+            + r'\bGestalt\b|' \
+            + r'\bGStreamer\b|' \
+            + r'\bInterleave\b|' \
+            + r'\bM_PToP\b|' \
+            + r'\bM_PToT\b|' \
+            + r'\bM_TToP\b|' \
+            + r'\bM_TToT\b|' \
+            + r'\bOSAUCSTest\b|' \
+            + r'\bOSName\b|' \
+            + r'\bPriority\b|' \
+            + r'\bPsychometric\b|' \
+            + r'\bRandi\b|' \
+            + r'\bRanint\b|' \
+            + r'\bReplace\b|' \
+            + r'\bResolute\b|' \
+            + r'\bRush\b|' \
+            + r'\bSample\b|' \
+            + r'\bScale\b|' \
+            + r'\bShuffle\b|' \
+            + r'\bSnd\b|' \
+            + r'\bStopwatch\b|' \
+            + r'\bTrunc\b|' \
+            + r'\bXYZTouv\b|' \
+            + r'\bhexstr\b|' \
+            + r'\bmoglmorpher\b|' \
+            + r'\bpsychassert\b|' \
+            + r'\bpsychlasterror\b|' \
+            + r'\bpsychrethrow\b|' \
+            + r'\bsca\b|' \
+            + r'\buvTols\b|' \
+            + r'\buvToxy\b|' \
+            + r'\buvYToXYZ\b|' \
+            + r'\bxyTouv\b|' \
+            + r'\bxyYToXYZ\b|' \
+            + r'\blog10nw\b|' \
+            + r'\bPreference\b)'
+
+    if outputFormat == "markdown":
+        mkstring = re.sub(match,r'[\1](\1)',mkstring)
+    elif outputFormat == "mediawiki":
+        mkstring = re.sub(match,r'[[\1|\1]]',mkstring)
+
+
+    #Add links for any word using UpperCamelCase: e.g. PsychHID
+    #BUT does NOT match any string stating wiht ' e.g. 'OpenWindow'
+    #Because we don't want subfunctions/strings to trigger page links
+    #WARNING:
+    #This is a pretty crazy regex to .  Cobled together from lots of
+    #web searches and tests.  Probably not very robust but gets most of the job done.
+    UpperCamelMatch = r'(?<!\')(?:\(|\b)[A-Z]([A-Z0-9]*[a-z][a-z0-9]*[A-Z]|[a-z0-9]*[A-Z][A-Z0-9]*[a-z])[A-Za-z0-9]*(?:\)|\b)(?!\')'
+    #r'(?<!\')[A-Z]([A-Z0-9]*[a-z][a-z0-9]*[A-Z]|[a-z0-9]*[A-Z][A-Z0-9]*[a-z])[A-Za-z0-9]*'
+
+    if outputFormat == "markdown":
+        mkstring = re.sub(UpperCamelMatch,r'[\g<0>](\g<0>)',mkstring)
+    elif outputFormat == "mediawiki":
+        mkstring = re.sub(UpperCamelMatch,r'[[\g<0>|\g<0>]]',mkstring)
+
+
+
+    # purge useless help lines
+    mkstring = re.sub(r'(?m)^.*triple-click me & hit enter.*$\n','',mkstring)
+    # Generate more headlines (Word:$, CAPITAL LETTERS$, etc)
+    mkstring = re.sub(r'(?m)((?<=\n\n).+:((?=\s*\n\n)+))', r'### \1',mkstring)
+    mkstring = re.sub('(?m)((?<=\n\n)\ *[A-Z][A-Z :!-]+\ *(?=\n))', r'### \1',mkstring)
+
+    #media wiki interprets whitespace at beggining of line as code block
+    if outputFormat == "mediawiki":
+        mkstring = re.sub(r'^\s+','',mkstring,flags=re.M)
+
+    if outputFormat == "markdown":
+    # Add double space after lines for markdown to keep paragraph togethr
+        mkstring = re.sub(r'(\n)',r'  \n',mkstring)
+    elif outputFormat == "mediawiki":
+    #Add manual linebreaks to preserve formatting
+        mkstring = re.sub(r'(\n)',r'<br />\n',mkstring)
+
+    return mkstring
+
+def writeFiles(outputDir,files):
+    ''' create pages for all files in there and link to the category'''
+    for name in files:
+
+        from pathlib import Path
+        #Get absolute path for checking file parent.
+        absPath = os.path.abspath(name)
+        category = Path(Path(absPath).parent).stem
+
+        # single out some names
+        head, basename = os.path.split(name)
+        root =  os.path.join(os.path.basename(os.getcwd()))
+        path =   os.path.normpath(os.path.join(root,head))
+        funcname, ext = os.path.splitext(basename)
+
+        cattext = ''
+
+        mexname = os.path.join(absPath,funcname+_mexext)
+
+        if not os.path.exists(name) or not ext=='.m':
+            if _mexmode and ext == _mexext:
+                mexhelpextract(outputDir,[funcname])
+            elif _debug: print('skipping ' + name)
+            continue
+
+        #If mexmode is on and mex file exists skip .m file
+        if _mexmode and ext=='.m' and os.path.exists(mexname):
+            print('Mex file exists. skipping m file: ' + name )
+            continue
+
+        if basename=='Contents.m' or basename=='contents.m':
+            funcname = category
+            # path = os.path.dirname(path)
+            # #Sooo Kludgy.  SHould update directory parsing.
+            # if len(path) < 3:
+            #     funcname = 'Psychtoolbox'
+            cattext = '{{category}}'
+
+        # load and build the text for the page
+        headline = "# [[" + funcname + "]]\n"
+        breadcrumb = "## [[" + re.sub("/","]] &#8250; [[", path) + "]]\n\n"
+
+        # read the .m-file and strip all the crap
+        docstring = parse(name)
+
+        # scrub the text real good, to get us some nice wiki formatting
+        if docstring:
+            body = beackern(docstring)
+        else:
+            body = 'Adrian, this function is not yet documented.\n\n\n MissingDocs'
+
+        pathlinks = """
+                    <div class="code_header" style="text-align:right;">
+                      <span style="float:left;">Path&nbsp;&nbsp;</span> <span class="counter">Retrieve <a href=
+                      "https://raw.github.com/Psychtoolbox-3/Psychtoolbox-3/beta/%s">current version from GitHub</a> | View <a href=
+                      "https://github.com/Psychtoolbox-3/Psychtoolbox-3/commits/beta/%s">changelog</a></span>
+                    </div>
+                    <div class="code">
+                      <code>%s</code>
+                    </div>
+                    """% tuple([os.path.join(path,basename)]*3)
+
+        text =  breadcrumb \
+                + body \
+                + '\n\n\n' \
+                + textwrap.dedent(pathlinks) \
+                + '\n' \
+                + cattext
+
+        if outputFormat == "markdown":
+            suffix = '.md'
+        elif outputFormat == "mediawiki":
+            suffix = '.wiki'
+
+        wikiFileName = os.path.join(outputDir,funcname + suffix)
+        print("writing file %s"%wikiFileName)
+
+        f = open(wikiFileName,"w+")
+        f.write(text)
+
+
+
+def parseMexExtract(filename):
+    from collections import defaultdict
+    sectionPattern = re.compile(r'\[section:(.*?)\]')
+    keyPattern = re.compile(r'\[key:(.*?)\]')
+
+    extractedText = defaultdict(lambda: defaultdict(str))
+
+    with open(filename) as toParse:
+
+        for line in toParse:
+
+            sectionMatch = sectionPattern.match(line)
+            keyMatch     = keyPattern.match(line)
+            if sectionMatch:
+                sectionName = sectionMatch.groups()[0]
+            elif keyMatch:
+                keyName = keyMatch.groups()[0]
+            else:
+                extractedText[sectionName][keyName]=extractedText[sectionName][keyName]+line
+
+    return extractedText
+
+
+def formatUsage(usage,mexname,subfunctions):
+
+    if outputFormat == "markdown":
+    # Add double space after lines for markdown to keep paragraph togethr
+        usage = re.sub(r'(\n)',r'  \n',usage)
+    elif outputFormat == "mediawiki":
+    #Add manual linebreaks to preserve formatting
+        usage = re.sub(r'(\n)',r'<br />\n',usage)
+
+    #Now parse the usage block to add links to sub function help
+    #Looking for pattern: mexfile('subfunc'
+
+    for subFuncName,subFuncText in subfunctions.items():
+
+
+        if outputFormat == "markdown":
+            usage = re.sub( \
+            mexname+'\(\'' +subFuncName + '\'', \
+            mexname+'(\'[' + subFuncName + '](' + mexname + '-' + subFuncName + ')\'', \
+            usage)
+        elif outputFormat == "mediawiki":
+            usage = re.sub( \
+            mexname+'\(\'' +subFuncName + '\'', \
+            mexname+'(\'[[' + mexname + '-' + subFuncName + '|'  + subFuncName + ']]\'', \
+            usage)
+
+
+
+    return usage
+
+def mexhelpextract(outputDir,mexnames):
+    #print 'processing mex files: ' + mexnames.__repr__()
+    for mexname in mexnames:
+        # First build help text for mex.
+
+        # assemble command line for matlab
+        matlabcmd = 'addpath(\'%s\');%s(\'%s\',\'%s\'); exit' % \
+            (_tmpdir, \
+             os.path.splitext(os.path.basename(_mexscript))[0], \
+             mexname, \
+             _tmpdir)
+        cmd = 'matlab -nojvm -nodisplay -r "%s" > /dev/null' % matlabcmd
+        # and execute matlab w/ the temporary script we wrote earlier
+        try:
+            print('running MATLAB for %s in %s' % (mexname,_tmpdir))
+            p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT, close_fds=True)
+            stderr = p.communicate()[1]
+            if stderr: print(stderr)
+        except:
+            print('could not dump help for %s into %s.' % (mexname,_tmpdir))
+
+        mexDumpName = os.path.join(_tmpdir,mexname);
+
+        if not os.path.isfile(mexDumpName):
+            print("skipping " + mexname + " (no output)")
+            continue
+
+        # Parse the mex dumped file using the following format:
+        # [Section:SubFunction]
+        # [key:usage]
+        # usage text
+        # [key:help]
+        # help text
+        # [key:seealso]
+        # see  also text
+
+        subfunctions = parseMexExtract(mexDumpName)
+
+        subFuncList = ''
+        for key in subfunctions:
+            subFuncList = subFuncList + ', ' + key
+
+        print('processing subfunctions: ' + subFuncList)
+
+        for subFuncName,subFuncText in subfunctions.items():
+            # read in the strings for this subfunction
+            usage = subFuncText['usage']
+            help = subFuncText['help']
+            seealso = subFuncText['seealso']
+
+            headline = '# ['+mexname+'(\''+subFuncName+'\')](' \
+                        + mexname + '-' + subFuncName + ') ' + '\n'
+
+            breadcrumb = "## [[Psychtoolbox]] &#8250; [[" \
+                                + mexname + "]].{mex*,dll} subfunction\n\n"
+
+            # scrub the text for main text only
+            body = beackern(help)
+
+            if subFuncName == '__main__':
+                usage = formatUsage(usage,mexname,subfunctions)
+                headline = "# [[" + mexname + "]]\n"
+            # docstring = '' \
+            #         + '%%(matlab;Usage)' \
+            #         + usage \
+            #         + '%%\n' \
+            #         + body \
+            #         + '\n\n'
+            docstring = ''  \
+                    + usage \
+                    + '\n' \
+                    + body \
+                    + '\n\n'
+
+            print(seealso)
+            if seealso:
+
+                #Add links for any word using UpperCamelCase: e.g. PsychHID
+                #BUT does NOT match any string stating wiht ' e.g. 'OpenWindow'
+                #Because we don't want subfunctions/strings to trigger page links
+                #WARNING:
+                #This is a pretty crazy regex to .  Cobled together from lots of
+                #web searches and tests.  Probably not very robust but gets most of the job done.
+                UpperCamelMatch = r'(?<!\')(?:\(|\b)[A-Z]([A-Z0-9]*[a-z][a-z0-9]*[A-Z]|[a-z0-9]*[A-Z][A-Z0-9]*[a-z])[A-Za-z0-9]*(?:\)|\b)(?!\')'
+                #r'(?<!\')[A-Z]([A-Z0-9]*[a-z][a-z0-9]*[A-Z]|[a-z0-9]*[A-Z][A-Z0-9]*[a-z])[A-Za-z0-9]*'
+
+                if outputFormat == "markdown":
+                    seealso = re.sub(UpperCamelMatch,r'[\g<0>]('+mexname + '-\g<0>)',seealso)
+                elif outputFormat == "mediawiki":
+                    seealso = re.sub(UpperCamelMatch,r'[['+mexname + '-\g<0>|\g<0>]]',seealso)
+
+
+                docstring = docstring + '###See also:\n' + seealso
+
+            text =  headline \
+                    + breadcrumb \
+                    + docstring
+
+
+            if outputFormat == "markdown":
+                suffix = '.md'
+            elif outputFormat == "mediawiki":
+                suffix = '.wiki'
+
+            wikiFileName = os.path.join(outputDir,mexname + '-' + subFuncName + suffix)
+            if subFuncName == '__main__':
+                wikiFileName = os.path.join(outputDir,mexname + suffix)
+
+            print("writing file " + wikiFileName)
+
+            f = open(wikiFileName,"w+")
+            f.write(text)
+
+def recursivewalk(outputDir,rootfolder):
+    '''traverse the root directory and post all .m-files'''
+    for root, dirs, files in os.walk(rootfolder):
+
+        if re.search(os.sep+'\.svn|'+os.sep+'private',root):
+                continue
+        print('Entering folder ' + root)
+
+        # .m-files are processed with postsinglefiles
+        mfiles = [os.path.join(root,f) for f in files \
+                if f.endswith(('.m','.M',_mexext))]
+        writeFiles(outputDir,mfiles)
+
+        # # mex files are processed via matlab
+        # if _mexmode:
+        #     mexnames = [os.path.splitext(f)[0] for f in files \
+        #             if f[-len(_mexext):].lower() == _mexext]
+        #     mexhelpextract(mexnames)
+
+    print("Exiting: Done with this tree.")
+    sys.exit(0)
+
+def usage():
+    print(__doc__)
+
+def main(argv):
+
+    try:
+        opts, args = getopt.getopt(argv, "h:o:f:rmv", \
+            ["help", "output-dir=", "format=", "recursive","mexmode"])
+    except getopt.GetoptError:
+        usage()
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt in ("-h", "--help"):
+            usage()
+            sys.exit()
+        elif opt in ("-o", "--output-dir"):
+            global outputDir
+            outputDir = arg
+        elif opt in ("-f", "--format"):
+            global outputFormat
+            print(arg)
+
+            if arg.lower() not in ('markdown','mediawiki'):
+                print('Error: output format must be either markdown or mediawiki\n\n')
+                sys.exit(1)
+            outputFormat = arg.lower()
+        elif opt in ("-r", "--recursive"):
+            global _recursive
+            _recursive = 1
+        elif opt in ("-m", "--mexmode"):
+            import tempfile
+            global _mexmode, _mexext, _tmpdir, _mexscript
+            _mexmode = 1
+            _tmpdir = tempfile.mkdtemp(prefix="PTB-doc-mexfunctionhelp-")
+            _mexscript = os.path.join(_tmpdir, 'PsychtoolboxMexhelpextract.m')
+            fid = open(_mexscript, 'w')
+            script = '''\
+            function PsychtoolboxMexhelpextract(mexname,tmpdir)
+            try
+                subfunctions=eval([mexname '(''DescribeModulefunctionshelper'')']);
+            catch
+                return;
+            end
+
+            try
+                if isempty(subfunctions)
+                    return;
+                end
+
+                if ~iscell(subfunctions)
+                    return;
+                end
+            catch
+                return;
+            end
+
+            fid = fopen(fullfile(tmpdir,mexname),'wt');
+            if fid == -1
+                return;
+            end
+
+            try
+                %first extract help for main function, including subfunction list
+                fprintf(fid,'[section:__main__]\\n');
+                synopsisText = evalc([mexname ';']);
+                helpText     = help(mexname);
+                fprintf(fid,'[key:usage]\\n%s\\n',synopsisText);
+                fprintf(fid,'[key:help]\\n%s\\n',helpText);
+                fprintf(fid,'[key:seealso]\\n');
+
+                for i=1:size(subfunctions,2)
+                    fprintf(fid,'[section:%s]\\n',subfunctions{i});
+                    docs = eval([mexname '(''DescribeModulefunctionshelper'',1,subfunctions{i})']);
+                    fprintf(fid,'[key:usage]:%s\\n',docs{1});
+                    fprintf(fid,'[key:help]\\n%s\\n',docs{2});
+                    fprintf(fid,'[key:seealso]\\n%s\\n',docs{3});
+                end
+            catch
+                % Nothing to do.
+            end
+
+            fclose(fid);
+            return
+            '''
+            fid.write(textwrap.dedent(script))
+            fid.close()
+
+        elif opt == '-v':
+            global _debug
+            _debug = 1
+
+    if args:
+        if _recursive:
+            if len(args) == 1 and os.path.isdir(args[0]):
+                recursivewalk(outputDir,args[0])
+            else:
+                usage()
+                print('Error: Recursive mode works with one directory only\n\n')
+                sys.exit(1)
+
+        else:
+            print("Parsing Input: " + str(args[0]) + " writing to: " + outputDir)
+            writeFiles(outputDir,args)
+    else:
+        usage()
+        print('Error: No files specified to submit to Wiki\n\n')
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
This function supports exporting ptb help text into formatted files.  These can be used to directly add into a github wiki repository, or github pages repository (note github pages need config setting: permalink:  /:title.html)

Also since these are formatted files they can be adapted to different formats using  pandoc (e.g. html) and that can support using various other platforms.  

It's not obvious what platform is the best for hosting going forward one is best

Problem:
The GitHub Wiki platform cannot hold a dump of all the files.  Specifically the PsychOpenGL folder has many files in it. When these are included the GitHub wiki starts throwing rendering took to long errors on pages with more than ~20 links. 

The GitHub Pages platform also throws a build time error timeout when trying to include all files.

The sites seem to work when the subfolders in PsychOpenGL are excluded.

Example output committed to wiki in forked repository:
https://github.com/aleslab/Psychtoolbox-3-aleslab-fork/wiki


ToDo
Add initial landing page
Fix/improve formatting . 
Fix SeeAlso blocks missing links for some keywords. 
