### PR TITLE
Update BackupCluts.m

### DIFF
--- a/Psychtoolbox/PsychOneliners/BackupCluts.m
+++ b/Psychtoolbox/PsychOneliners/BackupCluts.m
@@ -13,6 +13,7 @@ function BackupCluts(screenIds)
 
 % History:
 % 28.09.2010   mk   Written.
+% 02.09.2019   ia   Fix screen 0 on windows causing an error.
 
 % Store backup copies of clut's for later restoration by RestoreCluts():
 global ptb_original_gfx_cluts;
@@ -31,6 +32,7 @@ end
 if isempty(screenIds)
     screenIds = Screen('Screens');
 end
+screenIds(screenIds==0) = []; % remove screens with 0 index
 
 for screenid = screenIds
     % Do we have already a backed up original clut for 'screenid'?

--- a/Psychtoolbox/PsychOneliners/BackupCluts.m
+++ b/Psychtoolbox/PsychOneliners/BackupCluts.m
@@ -32,7 +32,9 @@ end
 if isempty(screenIds)
     screenIds = Screen('Screens');
 end
-screenIds(screenIds==0) = []; % remove screens with 0 index
+if length(screenIds > 1) %we have more than one screen 
+    screenIds(screenIds==0) = []; % remove screens with 0 index
+end
 
 for screenid = screenIds
     % Do we have already a backed up original clut for 'screenid'?

--- a/Psychtoolbox/PsychOneliners/BackupCluts.m
+++ b/Psychtoolbox/PsychOneliners/BackupCluts.m
@@ -32,7 +32,7 @@ end
 if isempty(screenIds)
     screenIds = Screen('Screens');
 end
-if length(screenIds > 1) %we have more than one screen 
+if IsWin && length(screenIds > 1) %we have more than one screen 
     screenIds(screenIds==0) = []; % remove screens with 0 index
 end
 

--- a/Psychtoolbox/PsychOneliners/BackupCluts.m
+++ b/Psychtoolbox/PsychOneliners/BackupCluts.m
@@ -32,7 +32,7 @@ end
 if isempty(screenIds)
     screenIds = Screen('Screens');
 end
-if IsWin && length(screenIds > 1) %we have more than one screen 
+if IsWin && length(screenIds) > 1 %we have more than one screen on windows
     screenIds(screenIds==0) = []; % remove screens with 0 index
 end
 


### PR DESCRIPTION
Fixes #153 for multi-monitor Windows systems having a virtual screen indexed to 0 which cannot be read from.