### PR TITLE
add PsychOneliners folder to path.

### DIFF
--- a/Psychtoolbox/UpdatePsychtoolbox.m
+++ b/Psychtoolbox/UpdatePsychtoolbox.m
@@ -64,6 +64,9 @@ function UpdatePsychtoolbox(targetdirectory, targetRevision)
 % 04/01/16 mk  64-Bit Octave-4 support for MS-Windows established.
 % 06/01/16 mk  32-Bit Octave-4 support for MS-Windows removed.
 % 06/01/19 mk  Give automated hint about updated svn client under Matlab.
+% 10/31/19 dgp Allows UpdatePsychtoolbox to run without Psychtoolbox in path. 
+
+addpath(fullfile(fileparts(mfilename('fullpath')),'PsychOneliners'));
 
 % Flush all MEX files: This is needed at least on M$-Windows for SVN to
 % work if Screen et al. are still loaded.


### PR DESCRIPTION
I often run UpdatePsychtoolbox when MATLAB does not have Psychtoolbox in its path. UpdatePsychtoolbox sets up the path correctly. However, to run, UpdatePsychtoolbox needs to use 
Psychtoolbox/PsychOneliners/PsychRoot.m
so this change adds the PsychOneliners folder to the path, assuming that UpdatePsychtoolbox is in the Psychtoolbox folder. It not, this generates a harmless warning.