### PR TITLE
Screen/Linux: Add our own custom VRR scheduler.

### DIFF
--- a/PsychSourceGL/Source/Common/Screen/PsychImagingPipelineSupport.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychImagingPipelineSupport.c
@@ -708,6 +708,19 @@ void PsychInitializeImagingPipeline(PsychWindowRecordType *windowRecord, int ima
     // Decide on proper format:
     finalizedFBOFormat = (redbits <= 8) ? GL_RGBA8 : ((windowRecord->gfxcaps & kPsychGfxCapFPFBO32) ? GL_RGBA_FLOAT32_APPLE : GL_RGBA16_SNORM);
 
+    // Use of VRR mode with our own custom scheduler requested?
+    if (windowRecord->vrrMode == kPsychVRROwnScheduled) {
+        // Create one finalizedFBO[0] for the virtual backbuffer that will be blitted into the real backbuffer, then
+        // VRR scheduled for stimulus onset:
+        if (!PsychCreateFBO(&(windowRecord->fboTable[fbocount]), finalizedFBOFormat, FALSE, winwidth, winheight, 0, 0)) {
+            // Failed!
+            PsychErrorExitMsg(PsychError_system, "Imaging Pipeline setup: Could not setup stage 0 of imaging pipeline for my own VRR scheduler.");
+        }
+
+        windowRecord->finalizedFBO[0] = fbocount;
+        fbocount++;
+    }
+
     if ((windowRecord->stereomode == kPsychDualWindowStereo) || (imagingmode & kPsychNeedDualWindowOutput)) {
         // Dual-window stereo or dual window output is a special case: This window contains the imaging pipeline for
         // both views, but its OpenGL context and framebuffer only represents the left-view channel.
@@ -1232,7 +1245,7 @@ void PsychInitializeImagingPipeline(PsychWindowRecordType *windowRecord, int ima
                 }
 
                 if (windowRecord->stereomode > 0) {
-                    // Delete and recreate finalizedFBO[0] with our new backingstore:
+                    // Delete and recreate finalizedFBO[1] with our new backingstore:
                     winwidth = windowRecord->fboTable[windowRecord->finalizedFBO[1]]->width;
                     winheight = windowRecord->fboTable[windowRecord->finalizedFBO[1]]->height;
                     PsychDeleteFBO(windowRecord->fboTable[windowRecord->finalizedFBO[1]]);
@@ -1301,7 +1314,7 @@ void PsychInitializeImagingPipeline(PsychWindowRecordType *windowRecord, int ima
                 }
 
                 if (windowRecord->stereomode > 0) {
-                    // Delete and recreate finalizedFBO[0] with our new backingstore:
+                    // Delete and recreate finalizedFBO[1] with our new backingstore:
                     winwidth = windowRecord->fboTable[windowRecord->finalizedFBO[1]]->width;
                     winheight = windowRecord->fboTable[windowRecord->finalizedFBO[1]]->height;
                     format = windowRecord->fboTable[windowRecord->finalizedFBO[1]]->format;

--- a/PsychSourceGL/Source/Common/Screen/PsychWindowSupport.h
+++ b/PsychSourceGL/Source/Common/Screen/PsychWindowSupport.h
@@ -26,7 +26,7 @@
 
 #include "Screen.h"
 
-psych_bool PsychOpenOnscreenWindow(PsychScreenSettingsType *screenSettings, PsychWindowRecordType **windowRecord, int numBuffers, int stereomode, double* rect, int multiSample, PsychWindowRecordType* sharedContextWindow, psych_int64 specialFlags, int vrrMode, double vrrMinDuration, double vrrMaxDuration);
+psych_bool PsychOpenOnscreenWindow(PsychScreenSettingsType *screenSettings, PsychWindowRecordType **windowRecord, int numBuffers, int stereomode, double* rect, int multiSample, PsychWindowRecordType* sharedContextWindow, psych_int64 specialFlags, PsychVRRModeType vrrMode, PsychVRRStyleType vrrStyleHint, double vrrMinDuration, double vrrMaxDuration);
 void    PsychCloseOnscreenWindow(PsychWindowRecordType *windowRecord);
 void    PsychCloseWindow(PsychWindowRecordType *windowRecord);
 void    PsychFlushGL(PsychWindowRecordType *windowRecord);
@@ -59,6 +59,7 @@ void    PsychBackupFramebufferToBackingTexture(PsychWindowRecordType *backupRend
 int     PsychFindFreeSwapGroupId(int maxGroupId);
 unsigned int PsychGetNrAsyncFlipsActive(void);
 unsigned int PsychGetNrFrameSeqStereoWindowsActive(void);
+unsigned int PsychGetNrVRRSchedulerWindowsActive(void);
 psych_bool PsychIsMasterThread(void);
 void PsychLockedTouchFramebufferIfNeeded(PsychWindowRecordType *windowRecord);
 

--- a/PsychSourceGL/Source/Common/Screen/SCREENGetWindowInfo.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENGetWindowInfo.c
@@ -205,7 +205,9 @@ static char synopsisString[] =
     "SwapBarrier: Swap barrier id of the swap barrier to which this windows swap group is assigned. Zero for none.\n"
     "SysWindowHandle: Low-level windowing system specific window handle of the onscreen window. Currently Linux/X11 only: The X-Window handle.\n"
     "ExternalMouseMultFactor: Scaling factor to apply for remapping input coordinates on some systems, e.g., by RemapMouse.m.\n"
-    "VRRMode: Actual selected mode for VRR stimulus onset scheduling (1 = auto maps to actual choice): 0 = Off, 2 = Simple.\n"
+    "VRRMode: Actual selected mode for VRR stimulus onset scheduling (1 = auto maps to actual choice): 0 = Off, 2 = Simple, 3 = OwnScheduled.\n"
+    "VRRStyleHint: Style hint code for the current active VRR stimulation timing style, ie. what is assumed about timing behaviour of the paradigm.\n"
+    "VRRLatencyCompensation: Current estimate of average VRR swapbuffers latency, used for compensating during VRR scheduling in 'OwnScheduled' mode.\n"
     "\n"
     "The following settings are derived from a builtin detection heuristic, which works on most common GPU's:\n\n"
     "GPUCoreId: Symbolic name string that roughly describes the name of the GPU core of the graphics card. This string is arbitrarily\n"
@@ -233,8 +235,9 @@ PsychError SCREENGetWindowInfo(void)
                                 "VBLTimePostFlip", "OSSwapTimestamp", "GPULastFrameRenderTime", "StereoMode", "ImagingMode", "MultiSampling", "MissedDeadlines", "FlipCount", "StereoDrawBuffer",
                                 "GuesstimatedMemoryUsageMB", "VBLStartline", "VBLEndline", "VideoRefreshFromBeamposition", "GLVendor", "GLRenderer", "GLVersion", "GPUCoreId", "GPUMinorType",
                                 "DisplayCoreId", "GLSupportsFBOUpToBpc", "GLSupportsBlendingUpToBpc", "GLSupportsTexturesUpToBpc", "GLSupportsFilteringUpToBpc", "GLSupportsPrecisionColors",
-                                "GLSupportsFP32Shading", "BitsPerColorComponent", "IsFullscreen", "SpecialFlags", "SwapGroup", "SwapBarrier", "SysWindowHandle", "ExternalMouseMultFactor", "VRRMode" };
-    const int fieldCount = 40;
+                                "GLSupportsFP32Shading", "BitsPerColorComponent", "IsFullscreen", "SpecialFlags", "SwapGroup", "SwapBarrier", "SysWindowHandle", "ExternalMouseMultFactor", "VRRMode",
+                                "VRRStyleHint", "VRRLatencyCompensation" };
+    const int fieldCount = 42;
     PsychGenericScriptType *s;
 
     PsychWindowRecordType *windowRecord;
@@ -553,6 +556,12 @@ PsychError SCREENGetWindowInfo(void)
 
         // Effectively selected VRR mode - ergo excluding 1 for "automatic", as that one would have mapped to a > 1 mode already:
         PsychSetStructArrayDoubleElement("VRRMode", 0, windowRecord->vrrMode, s);
+
+        // Current assumption about VRR timing style:
+        PsychSetStructArrayDoubleElement("VRRStyleHint", 0, windowRecord->vrrStyleHint, s);
+
+        // Current assumption about VRR system latency:
+        PsychSetStructArrayDoubleElement("VRRLatencyCompensation", 0, windowRecord->vrrLatencyCompensation, s);
 
         // Which basic GPU architecture is this?
         PsychSetStructArrayStringElement("GPUCoreId", 0, windowRecord->gpuCoreId, s);

--- a/PsychSourceGL/Source/Common/Screen/ScreenTypes.h
+++ b/PsychSourceGL/Source/Common/Screen/ScreenTypes.h
@@ -92,6 +92,17 @@ typedef enum  {
 } PsychStereoDisplayType;
 
 typedef enum {
+    kPsychVRROff =              0,      // VRR disabled.
+    kPsychVRRAuto =             1,      // VRR mode to be auto-selected from one of the modes below this line:
+    kPsychVRRSimple =           2,      // VRR simple scheduling - Standard flip scheduling with call to swapbuffer.
+    kPsychVRROwnScheduled =     3       // VRR scheduling via our own custom scheduler, running on the flipper-thread.
+} PsychVRRModeType;
+
+typedef enum {
+    kPsychVRRStyleNone =            0   // No style hint given. Make as little assumptions about timing characteristics as possible. Try "one size fits all".
+} PsychVRRStyleType;
+
+typedef enum {
     kPsychUnknownColor = 0,
     kPsychRGBColor,             // means PsychRGBColorType
     kPsychRGBAColor,            // means RGBColorType with alpha channel

--- a/PsychSourceGL/Source/Common/Screen/WindowBank.h
+++ b/PsychSourceGL/Source/Common/Screen/WindowBank.h
@@ -490,9 +490,11 @@ typedef struct _PsychWindowRecordType_{
     double                      internalMouseMultFactor;            // Used by GetMouse et al to rescale mouse position on HiDPI displays.
     double                      externalMouseMultFactor;            // Used by external mouse mapping to rescale mouse position on HiDPI displays.
 
-    int                         vrrMode;                            // Mode of stimulus onset time scheduling: 0 = Fixed rate, > 0 = VRR style.
-    double                      vrrMinDuration;                     // Minimum possible video refresh duration for given associated VRR display.
-    double                      vrrMaxDuration;                     // Maximum possible video refresh duration for given associated VRR display.
+    PsychVRRModeType            vrrMode;                            // Mode of stimulus onset time scheduling: 0 = Fixed rate, > 0 = VRR style.
+    PsychVRRStyleType           vrrStyleHint;                       // Style hint code for type of VRR stimulation for current onscreen window.
+    double                      vrrMinDuration;                     // Minimum possible video refresh duration (secs) for given associated VRR display.
+    double                      vrrMaxDuration;                     // Maximum possible video refresh duration (secs) for given associated VRR display.
+    double                      vrrLatencyCompensation;             // Amount of time to subtract from requested stimulus onset time for system latency compensation.
 
     // Used only when this structure holds a window:
     // CAUTION FIXME TODO: Due to some pretty ugly circular include dependencies in the #include chain of

--- a/PsychSourceGL/Source/OSX/Screen/PsychWindowGlue.c
+++ b/PsychSourceGL/Source/OSX/Screen/PsychWindowGlue.c
@@ -846,7 +846,7 @@ psych_bool PsychOSOpenOnscreenWindow(PsychScreenSettingsType *screenSettings, Ps
 
         // Pass through as simple mode, because our caller needs to know if VRR was requested
         // to be enabled - this then triggers proper error handling in caller:
-        windowRecord->vrrMode = 2;
+        windowRecord->vrrMode = kPsychVRRSimple;
     }
 
     // Done.

--- a/PsychSourceGL/Source/Windows/Screen/PsychWindowGlue.c
+++ b/PsychSourceGL/Source/Windows/Screen/PsychWindowGlue.c
@@ -1851,25 +1851,29 @@ dwmdontcare:
 
     // VRR handling for all MS-Windows drivers:
     switch (windowRecord->vrrMode) {
-        case 0: // Disable VRR:
-            windowRecord->vrrMode = 0;
+        case kPsychVRROff: // Disable VRR:
+            windowRecord->vrrMode = kPsychVRROff;
             break;
 
-        case 1: // Automatic selection of optimal supported method for this setup:
-            windowRecord->vrrMode = 2;
+        case kPsychVRRAuto: // Automatic selection of optimal supported method for this setup. Currently our own custom scheduler:
+            windowRecord->vrrMode = kPsychVRROwnScheduled;
             break;
 
-        case 2: // Classic / Legacy / Dumb VRR - Just swapbuffers when asked to: Not yet supported.
-            windowRecord->vrrMode = 2;
+        case kPsychVRRSimple: // Classic / Legacy / Dumb VRR - Just swapbuffers when asked to:
+            windowRecord->vrrMode = kPsychVRRSimple;
+            break;
+
+        case kPsychVRROwnScheduled: // Our own custom async scheduler:
+            windowRecord->vrrMode = kPsychVRROwnScheduled;
             break;
 
         default:
-            windowRecord->vrrMode = 0;
+            windowRecord->vrrMode = kPsychVRROff;
             if (PsychPrefStateGet_Verbosity() > 1)
                 printf("PTB-WARNING: Unsupported VRR mode %i requested. Disabling VRR.\n", windowRecord->vrrMode);
     }
 
-    if (windowRecord->vrrMode && (PsychPrefStateGet_Verbosity() > 1))
+    if ((windowRecord->vrrMode) && (PsychPrefStateGet_Verbosity() > 1))
         printf("PTB-WARNING: Unsupported VRR mode %i requested. Psychtoolbox for MS-Windows does not support VRR.\n", windowRecord->vrrMode);
 
     // Use vrrMinDuration "as is". Either userspace provided, or reasonable default of

--- a/Psychtoolbox/PsychGLImageProcessing/PsychImaging.m
+++ b/Psychtoolbox/PsychGLImageProcessing/PsychImaging.m
@@ -178,15 +178,34 @@ function [rc, winRect] = PsychImaging(cmd, varargin)
 %   There may be different methods of implementing such fine-grained timing.
 %   The optional 'method' parameter allows you to select a specific method.
 %   Using the keyword 'Auto' or omitting the 'method' parameter ([]) will leave
-%   the choice of optimal method to Screen(). Currently only the method 'Simple'
-%   is implemented, but this may change with future versions of Psychtoolbox.
+%   the choice of optimal method to Screen(). Currently the methods 'Simple' and
+%   'OwnScheduled' are implemented: 'Simple' follows the most naive approach of VRR,
+%   simply requesting immediate flip, or in case a 'when' time is specified, waiting
+%   until 'when', then requesting a flip. 'OwnScheduled' selects a more sophisticated
+%   scheduling method that tries to take other constraints like minimum and maximum
+%   refresh rate of the display, display system state, and a specified 'styleHint'
+%   for the given visual stimulation paradigm into account, and also tries to
+%   compensate for some of the system timing jitter. This may provide higher
+%   precision or stability in some stimulation scenarios, but may also cause
+%   higher overhead or added latency in other scenarios.
+%
+%   The optional parameter 'styleHint' allows to give some general high level clue
+%   into the nature of the visual stimulation paradigm, as far as presentation
+%   timing is concerned. This allows to tune the scheduling method for VRR for
+%   maximum precision and reliability for a stimulation paradigm of the specified
+%   nature. Omitting the parameter, or setting it to 'None', will ask the algorithm
+%   to make almost no assumptions about the nature of the stimulation, but to choose
+%   some "one size fits all ok'ish" setup, or try to auto-detect how to tune itself for
+%   the running paradigm. The currently supported 'styleHint' settings are:
+%
+%   - 'None' = Make no assumptions, try some "One size fits all hopefully ok'ish" setup.
 %
 %   The optional parameter 'vrrMinRefreshHz' allows to specify the lowest video
 %   refresh rate that your display can reliably run at. If the parameter is
 %   omitted, Screen() will try to auto-detect this display property, or failing
 %   that, it will use a reasonable default.
 %
-%   Usage: PsychImaging('AddTask', 'General', 'UseFineGrainedTiming' [, method='Auto'][, vrrMinRefreshHz]);
+%   Usage: PsychImaging('AddTask', 'General', 'UseFineGrainedTiming' [, method='Auto'][, styleHint='None'][, vrrMinRefreshHz]);
 %
 %
 % * 'UseSubpixelDrive' Ask to take advantage of the so-called "Subpixel Drive"
@@ -1769,11 +1788,23 @@ if strcmpi(cmd, 'OpenWindow')
             vrrMode = 1;
         elseif strcmpi(vrrMode, 'Simple')
             vrrMode = 2;
+        elseif strcmpi(vrrMode, 'OwnScheduled')
+            vrrMode = 3;
         else
-            error('PsychImaging: For task "UseFineGrainedTiming" invalid method argument specified. Must be ''Auto'' or ''Simple''.');
+            error('PsychImaging: For task "UseFineGrainedTiming" invalid method argument specified. Must be ''Auto'', ''Simple'', or ''OwnScheduled''.');
         end
 
-        vrrMinRefreshHz = reqs{row, 4};
+        vrrStyleHint = reqs{row, 4};
+
+        if isempty(vrrStyleHint) || strcmpi(vrrStyleHint, 'None')
+            vrrStyleHint = 0;
+        elseif strcmpi(vrrStyleHint, 'XXX')
+            vrrStyleHint = 1;
+        else
+            error('PsychImaging: For task "UseFineGrainedTiming" invalid styleHint argument specified. Must be ''None''.');
+        end
+
+        vrrMinRefreshHz = reqs{row, 5};
         if isempty(vrrMinRefreshHz)
             vrrMinRefreshHz = 0;
         elseif ~isnumeric(vrrMinRefreshHz) || ~isscalar(vrrMinRefreshHz) || vrrMinRefreshHz < 0
@@ -1788,7 +1819,7 @@ if strcmpi(cmd, 'OpenWindow')
         end
 
         % Build ovrvrrParams:
-        ovrvrrParams = [vrrMode, 0, vrrMinRefreshHz];
+        ovrvrrParams = [vrrMode, vrrStyleHint, 0, vrrMinRefreshHz];
     end
 
     if nargin < 13 || isempty(varargin{12})

--- a/Psychtoolbox/PsychTests/VRRTest.m
+++ b/Psychtoolbox/PsychTests/VRRTest.m
@@ -162,6 +162,10 @@ try
     Screen('FrameRate', screenNumber);
     Screen('Preference','Verbosity', oldverbo);
 
+    % Switch to FIFO realtime-priority and memory locking to reduce timing jitter
+    % and interruptions caused by other applications and the operating system itself:
+    Priority(MaxPriority(screenNumber));
+
     % Prepare window configuration for this script:
     PsychImaging('PrepareConfiguration')
 
@@ -192,7 +196,7 @@ try
     % Get window info struct about onscreen fullscreen window:
     winfo = Screen('GetWindowInfo', w);
 
-    fprintf('\nActual chosen VRR mode: %i\n', winfo.VRRMode);
+    fprintf('\nActual chosen VRR mode: %i, style %i, latency compensation %f msecs.\n', winfo.VRRMode, winfo.VRRStyleHint, 1000 * winfo.VRRLatencyCompensation);
     if winfo.VRRMode == 0
         fprintf('\nWARNING: VRR unsupported on this hardware + software combo! Fixed refresh is used!!!\n');
         fprintf('WARNING: Read "help VRRSupport" for setup and troubleshooting instructions.\n\n');
@@ -232,10 +236,6 @@ try
         % Perform calibration of optimal photo-diode trigger level:
         triggerlevel = PsychPhotodiode('CalibrateTriggerLevel', pdiode, w) %#ok<NASGU,NOPRT>
     end
-
-    % Switch to FIFO realtime-priority and memory locking to reduce timing jitter
-    % and interruptions caused by other applications and the operating system itself:
-    Priority(MaxPriority(w));
 
     % Get minimal frame duration 'ifi' from calibration loop:
     [ifi, nvalid, stddev ] = Screen('GetFlipInterval', w);


### PR DESCRIPTION
Add a new VRR mode, mode 3 (aka "OwnScheduled"). It can be passed as
mode 3 for the vrrParams=[mode, styleHint, minDuration, maxDuration]
argument vector to Screen('OpenWindow', ..., vrrParams);

Or preferrably it can be requested via a call to:

PsychImaging('AddTask', 'General', 'UseFineGrainedTiming', 'OwnScheduled');

In the current implementation, mode 3 / 'OwnScheduled' gets also
selected as current best default choice if mode 1 is selected in
Screen('OpenWindow') or 'Auto' is specified in PsychImaging via
PsychImaging('AddTask', 'General', 'UseFineGrainedTiming', 'Auto');

The difference to mode 2 / 'Simple' is that we don't simply wait
until the Screen('Flip', window, when); 'when' deadline and then
call glXSwapBuffers() to request a buffer swap at 'when' (or call
glXSwapBuffers() immediately for an immediate flip), but schedule
the exact time of swapbuffers calls to take information about the
specific constraints of the operating-system/display-drivers, gpu,
VRR display device into account, knowing how the VRR hardware
operates. We also try to compensate for average latency/jitter in
the display systems response to our swapbuffers calls.

We also use current display system state, like the time of the end
of the last vblank (= start of a new scanout cycle on the display),
the time of the last completed flip, current system time, and how
far into the future the next flip is requested. We aim to time
glXSwapBuffers() calls so that the requested stimulus onset time
'when' ideally falls into the extended variable length/duration
front-porch of the vblank, so the display engine can respond to
the page-flip right away, minimizing time between flip completion
and start of active scanout of the post-flip stimulus image. We aim
to avoid hitting the timeout condition of "max vblank duration
reached", which would cause a large dead-zone in which we can't
show the stimulus on time if 'when' falls into the dead-zone.

To achieve this, we reuse much of the infrastructure of our frame-
sequential stereo implementation for stereo shutter goggles.

At startup, calibrations of average system flip delay are performed,
in order to compensate for average system delay during operation.

The image post-processing pipeline is started up, and finalizedFBO[0]
is allocated as a dedicated "bounce-backbuffer" FBO, instead of
just redirecting to the windows system backbuffer.

The flipper thread is started as in frame-seq stereo or for async
flips, but the threads main-loop uses a different implementation:

1. All usercode driven stimulus rendering happens into the imaging
   pipelines drawBufferFBO as usual. At 'Flip' / 'DrawingFinished'
   time, all image post-processing is done by the pipeline and its
   shaders as usual per the imaging pipeline configuration.

2. The final stimulus image isn't rendered by the pipeline into the
   system backbuffer directly, but into the finalizedFBO[0] bounce
   FBO.

3. Like in an async flip, PsychFlipWindowBuffersIndirect() is used
   to pass the finalizedFBO to the flipper-thread, together with
   the target stimulus onset timestamp 'when'.

4. The flipper-thread is in one of three possible states:

   a) Idle/Prevent-timeout processing: If no new 'Flip' request is
      pending, the thread performs idle swapbuffers calls, taking
      the current active frontbuffer image, copying it into the
      backbuffer, then swapping it back into the new frontbuffer,
      iow. a no-op swap that doesn't change the actual stimulus
      image. The no-op swapbuffers calls are timed in a way to try
      to prevent vblank timeout condition in the display engines.

   b) Runup/Prevennt-timeout processing: If a new 'Flip' request
      with a new stimulus image is pending, try do a), while aiming
      to prevent timeout and place the 'when' Flip deadline into
      the extended front-porch of a future scanout cycle. This if
      the 'when' deadline is too far away from current time wrt.
      some criterion.

   c) Actual stimulus onset flip: After b) is over, and the target
      front-porch with 'when' in it is in reach, blit the new
      stimulus image from finalizedFBO into the system backbuffer.
      Then do a timed wait until shortly before 'when', taking
      measured average system timing delay into account, then
      swapbuffers the new stimulus, wait for swap completion, do
      the usual stimulus onset timestamping, post-flip operations,
      then transition back to state a) or b).

Note:

- This critically depends on the OS graphics stack providing very
  stable execution timing, which is the case for Linux with FOSS/Mesa,
  less so on Linux with NVidia proprietary driver, and would be way
  less stable on other operating systems.

- Precise and trustworthy timestamps about time of last flip/stimulus
  onset and last end of vblank are absolutely critical. Linux with
  FOSS/Mesa provides this with micro-second precision at all times
  on all supported driver + gpu combos. Linux on NVidia proprietary
  blob doesn't, so we have to use hackery and heuristic tricks to
  abuse our self-made beamposition timestamping to get reasonable
  timestamps. Ergo, Linux + NVidia proprietary driver, as needed
  for VRR on NVidia gpu's, ie. NVidia G-Sync, is expected to be
  less reliable and accurate. Nothing we can do about this. FOSS
  VRR implementations like AMD's FreeSync are therefore strongly
  recommended.

- As we are using the imaging pipelines finalizedFBO bounce
  buffering and the flipper thread, this method is incompatible
  with the following:

  - Frame-sequential shutter-goggles stereo: Also because shutter
    goggles need predictable fixed-duration video refresh cycles,
    which are at odds with VRR.

  - Dual-Display stereo involving a 2nd onscreen window or dual
    display that isn't hardware-syned in VRR mode to each other,
    as we need OS support for VRR flips sync'ed across display
    engines. Also we can't use a secondary slave onscreen window,
    as our bounce buffering / flipper thread does not support
    VRR.

  - Our own software display mirroring, because it would also
    depend on finalizedFBO's that are already used for VRR.

  - Dual stream stereo, and custom finalized FBO sinks.

  Trying to co-enable any of these with VRR will lead to an error
  abort and a message "Don't do this."

This implementation has been tested on Linux 5.4-rc7+ / 5.5 upcoming
under Ubuntu 19.10, Mesa 19.2.1, X-Server 1.20.5 with AMD gpu's
of the Polaris DCE-11 and Raven DCN-1 family for FreeSync VRR.
Some very light testing was also performed under Ubuntu 18.04.3 LTS
with NVidia 435-series drivers on a GeForce GTX 1070 Pascal gpu
for G-Sync. It works ok, a substantial improvement over the previous
'Simple' method for many use cases. VRRTest.m is used to demo and
validate VRR.

Future plans:

- While this baseline implementation is a good improvement, it
  is only a starting point, providing the infrastructure and initial
  proof-of-concept implementation. The scheduling algorithm will
  likely change substantially, to actually reach the goals described
  above as aims. We are not there yet.

- The current implementation also allow for passing in an optional
  vrrParams parameter 'styleHint', which allows the user script to
  give the VRR scheduler some hints about how the stimulation paradigm
  wants to work wrt. timing. PsychImaging exposes the same optional
  semantic 'styleHint'. Currently only one setting is accepted, which
  is 0 for 'OpenWindow' aka 'None' for PsychImaging. The idea would
  be that the scheduler can adapt its strategy or tuning parameters
  to give better onset timing precision iff the users script does
  stimulus onset timing according to the semantic high-level hint
  provided via 'styleHint'. E.g., a 'styleHint' could tell us that
  the user-code will usually request 'Flip's on short notice, e.g.,
  because stimulus onset is not known beforehand, but triggered by
  some external event like user input, key-presses, eye movements,
  external triggers. Or the app may tell us that stimulus ISI's will
  be spaced variable on a low millisecond timescale, or on a large
  (hundreds / thousands msecs, seconds) timescales, or that this is
  mostly fixed fps animation/movie playback, with no or little flip
  to flip variation, but unusual fps (ie. not 60 fps, 30 fps, 20 fps).
  Only time and applications will tell iff and how much and what type
  of styleHints we will need and if we actually can adapt in a
  meaningful effective way. Additional api may be needed to change
  strategy during a session, instead of having a fixed strategy per
  session.

- The focus here is on getting maximum performance out of Linux FOSS
  implementations of VRR like AMD's FreeSync or upcoming Intel variants,
  not on proprietary NVidia G-Sync implementations. Users have been
  advised to avoid NVidia and go for FOSS compatible implementations
  for years, so the burden of doing the wrong thing should be carried
  by them and not by people who listen to good advise.

- A future planned VRR implementation for Linux FOSS will offload most
  of the VRR processing to the OS via dedicated api's, as this should
  not only simplify our job, but put VRR to a whole new level of
  reliability, accuracy and precision. This will only work on FOSS
  drivers and is still at least 6-12 months away at this time, possibly
  longer. Therefore the current implementation will have to do for a
  while.