### PR TITLE
Update the SineGratingSmoothedApertureShader fragment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ managementtools/ptbregistration*
 *.VC.db
 *.suo
 *.sqlite
+.vscode/

--- a/Psychtoolbox/PsychGLImageProcessing/CreateProceduralSmoothedApertureSineGrating.m
+++ b/Psychtoolbox/PsychGLImageProcessing/CreateProceduralSmoothedApertureSineGrating.m
@@ -31,8 +31,8 @@ function [gratingid, gratingrect] = CreateProceduralSmoothedApertureSineGrating(
 % 'useAlpha' Optional, defaults to 0. Whether to use color (0) or alpha (1)
 %  for smoothing channel. Defaults to 0 (color).
 %
-% 'method' Optional. Whether to use cosine (0) or smoothstep(1) smoothing 
-%  function. Defaults to 0 (cosine).
+% 'method' Optional. Whether to use cosine (0), smoothstep(1) or 
+%  inverse smoothstep (2) smoothing function. Defaults to 0 (cosine).
 %
 % The function returns a procedural texture handle 'gratingid' that you can
 % pass to the Screen('DrawTexture(s)', windowPtr, gratingid, ...) functions

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SineGratingSmoothedApertureShader.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SineGratingSmoothedApertureShader.frag.txt
@@ -42,8 +42,13 @@ void main()
         Mod = clamp(Mod, 0.0, 1.0);
         Mod = cos(Mod * halfpi);
     }
-    else {
+    else if (Method == 1.0) {
         Mod = smoothstep(Radius,(Radius-Sigma),Dist);
+    }
+    /*we use smoothstep but invert our alpha so we can use the disc as a mask */
+    else if (Method == 2.0) {
+        Mod = smoothstep(Radius,(Radius-Sigma),Dist);
+        Mod = 1.0 - Mod;
     }
 
     /* Evaluate sine grating at requested position, frequency and phase: */
@@ -57,6 +62,6 @@ void main()
     }
     else {
         gl_FragColor.rgb = (baseColor.rgb * sv) + Offset.rgb;
-        gl_FragColor.a = (rawAlpha * Mod) + Offset.a;
+        gl_FragColor.a = Offset.a * Mod;
     }
 }

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SineGratingSmoothedApertureShader.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SineGratingSmoothedApertureShader.frag.txt
@@ -23,7 +23,6 @@ float Mod = 1.0;
 varying vec4  baseColor;
 varying float Phase;
 varying float FreqTwoPi;
-varying float rawAlpha;
 
 void main()
 {

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SineGratingSmoothedApertureShader.vert.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/SineGratingSmoothedApertureShader.vert.txt
@@ -31,7 +31,6 @@ attribute vec4 auxParameters0;
 varying vec4  baseColor;
 varying float Phase;
 varying float FreqTwoPi;
-varying float rawAlpha;
 
 void main()
 {
@@ -49,9 +48,6 @@ void main()
 
     /* Precalc a couple of per-patch constant parameters: */
     FreqTwoPi = auxParameters0[1] * twopi;
-
-    /* Passthrough of raw alpha value (modulateColor.a aka globalAlpha): */
-    rawAlpha = modulateColor.a;
 
     /* Premultiply the wanted Contrast to the color: */
     baseColor = modulateColor * Contrast * contrastPreMultiplicator;


### PR DESCRIPTION
This shader smooths the edge of a grating. By default `useAlpha` is turned OFF and smoothing uses the background color directly (alpha channel untouched). In this case **no change** will be seen by this fix. 

However when `useAlpha` is turned on, the shader should use the edge modifier (`Mod`)on the alpha channel directly. Previously the fragment shader combined the global and local alpha (`(rawAlpha * Mod) + Offset.a`) causing an undesired effect (as I originally contributed this it was my bug), and the edge is not smoothed. To fix this we use the Modifier value directly (`Offset.a * Mod`), which allows the edge to blend properly with the underlying color while leaving the rest unaffected. When the background colour and offset are the same (as is normally the case, e.g. [0.5 0.5 0.5 1]), then `useAlpha` ON/OFF now looks the same. If the background colour is different to the offset, now with `useAlpha`=ON the edge properly smooths.

I added an optional value = 2 to `Method` which copies what is done in the SmoothedDiscShader.frag (option to invert the smoothing mask). Previously it accepted 0 or 1, and so there will be no change unless you explicitly set this to 2.

In addition I added the `.vscode` folder to .gitignore, this folder gets generated if you use VS Code or VS Codium and shouldn't be tracked in git.