### PR TITLE
Typos found by codespell

### DIFF
--- a/Psychtoolbox/PsychDocumentation/BeampositionQueries.m
+++ b/Psychtoolbox/PsychDocumentation/BeampositionQueries.m
@@ -166,7 +166,7 @@
 % 2. System overload: Too many other applications are running in parallel
 % to Psychtoolbox, introducing severe timing noise into the calibration and
 % test loop. See 'help SyncTrouble' on what to do. This happens rather
-% seldomly.
+% seldom.
 %
 % 3. Driver bug: Not much you can do, except submit a bug report to Apple
 % or Microsoft for your specific hardware + software setup. This is by far
@@ -179,7 +179,7 @@
 % fail in a peculiar way. If PTB detects that failure case, it will enable
 % some workaround to keep the mechanism going at slightly reduced accuracy:
 % Timestamps will still be mostly jitter-free and consistent, so they are
-% fully useable for timestamping, timing checks and as a basis for timed
+% fully usable for timestamping, timing checks and as a basis for timed
 % stimulus presentation and animation. However, all returned timestamps
 % will contain a constant bias wrt. the real stimulus onset time of
 % somewhere between 20 microseconds and 1.5 milliseconds, depending on your
@@ -187,7 +187,7 @@
 % of your display in scanlines (including the invisible VBL interval)
 % anymore. Exact height is important for spot-on timestamps. Psychtoolbox
 % uses some safe, conservative value for its internal computations, so
-% results will be consistent and useable, but contain a small constant
+% results will be consistent and usable, but contain a small constant
 % offset.
 %
 % In some rare cases, PTB's automatic test fails to detect the bug and

--- a/Psychtoolbox/PsychDocumentation/ConserveVRAMSettings.m
+++ b/Psychtoolbox/PsychDocumentation/ConserveVRAMSettings.m
@@ -3,7 +3,7 @@
 % The command Screen('Preference', 'ConserveVRAM', mode); can be used to
 % enable a couple of special work-arounds inside Screen to work around
 % broken operating systems, graphics drivers or graphics hardware, or to
-% work around ressource limitations of graphics hardware.
+% work around resource limitations of graphics hardware.
 %
 % You define the requested workaround by setting the parameter 'mode' to a
 % sum of the following values:
@@ -56,8 +56,8 @@
 % imaging combo work at least when no stencil buffer is needed.
 %
 %
-% 32 == kPsychDontShareContextRessources: Do not share ressources between
-% different onscreen windows. Usually you want PTB to share all ressources
+% 32 == kPsychDontShareContextRessources: Do not share resources between
+% different onscreen windows. Usually you want PTB to share all resources
 % like offscreen windows, textures and GLSL shaders among all open onscreen
 % windows. If that causes trouble for some weird reason, you can prevent
 % automatic sharing with this flag.
@@ -121,7 +121,7 @@
 % Tell PTB to use the opposite texture format of what its auto-detection
 % thinks is optimal. Screen contains code to auto-detect certain type of
 % graphics chips with broken drivers and tries to work-around them by
-% chosing different parameters for fast texture creation in certains
+% choosing different parameters for fast texture creation in certains
 % circumstances. In case those vendors should ever fix their drivers and
 % thereby the built-in workaround becoming invalid, this allows to override
 % PTB's choice. This is mostly to work around broken ATI drivers on
@@ -302,7 +302,7 @@
 % Currently no such bugs exist, so this option is just to future-proof
 % your Psychtoolbox against potential bugs in future operating systems.
 % Bugs were present in Linux versions 3.13 - 3.15 for a short period of
-% time between April and July 2014 which made this workaround neccessary.
+% time between April and July 2014 which made this workaround necessary.
 % However, the workaround is automatically enabled on such Linux versions
 % without the need for this conservevram setting. The relevant Linux bugs
 % have been fixed by mid-July 2014, ie., at the time of this writing, in all

--- a/Psychtoolbox/PsychDocumentation/DisplayOutputMappings.m
+++ b/Psychtoolbox/PsychDocumentation/DisplayOutputMappings.m
@@ -52,7 +52,7 @@
 % 3. If 2. doesn't help or is infeasible or problematic, you can also tell
 %    Screen() about the true wiring by adding the command
 %    Screen('Preference', 'ScreenToHead', screen, head, crtc[, rank]); to the
-%    top of your script, before other Screen() commmands:
+%    top of your script, before other Screen() commands:
 %
 %    On OS/X or Windows, Screen('Preference', 'ScreenToHead', 0, 1, 1);
 %    would tell Screen() that the Psychtoolbox screen with screenid 0 is
@@ -66,7 +66,7 @@
 %    'rank' parameter controls which of multiple possible outputs per
 %    screen is remapped. The default 'rank' of 0 refers to the primary
 %    display output, the one which is used for stimulus onset timestamping
-%    or framerate queries. It may therefore be neccessary to play with the
+%    or framerate queries. It may therefore be necessary to play with the
 %    'rank' parameter as well on multi-display setups with multiple
 %    monitors per Psychtoolbox screen.
 %

--- a/Psychtoolbox/PsychDocumentation/DrawTextEncodingLocaleSettings.m
+++ b/Psychtoolbox/PsychDocumentation/DrawTextEncodingLocaleSettings.m
@@ -15,7 +15,7 @@
 % hebrew alphabet.
 %
 % Direct drawing of unicode text characters outside the BMP is possible in
-% the same way the default textrenderer if you've installed the neccessary
+% the same way the default textrenderer if you've installed the necessary
 % software as described in "help DrawTextPlugin". In that case, the unicode
 % code points may have values greater than 65535, ie., they are processed
 % internally as UTF-32 / UCS-4 characters - Each single number represents

--- a/Psychtoolbox/PsychDocumentation/HybridGraphics.m
+++ b/Psychtoolbox/PsychDocumentation/HybridGraphics.m
@@ -75,7 +75,7 @@
 % On Microsoft Windows a handshake method is used which maintains good framerates
 % for video games and similar applications, but causes visual stimulus onset timing
 % and timestamping to be almost always completely wrong, with observed errors in
-% the range of +/- 33 msecs on a 60 Hz panel. That means that the dGPU is unuseable
+% the range of +/- 33 msecs on a 60 Hz panel. That means that the dGPU is unusable
 % if visual timing matters in any way. The best you can do on a muxless laptop under
 % Microsoft Windows is to configure the driver to disable the dGPU and only use the
 % iGPU for all rendering, and then hope that the iGPU graphics driver isn't too buggy,
@@ -151,7 +151,7 @@
 %
 %   5. Copy the custom Psychtoolbox modesetting driver into the system driver directory.
 %      There are two variants, the nolag variant and the highlag variant. In theory, the
-%      nolag variant would be preferrable, but it sometimes gives inconsistent performance:
+%      nolag variant would be preferable, but it sometimes gives inconsistent performance:
 %
 %      sudo cp /pathto/Psychtoolbox/PsychHardware/LinuxDrivers/NVidiaOptimus/modesetting_drv.so /usr/lib/xorg/extra-modules/modesetting_drv.so
 %

--- a/Psychtoolbox/PsychDocumentation/InstallKinect.m
+++ b/Psychtoolbox/PsychDocumentation/InstallKinect.m
@@ -20,7 +20,7 @@
 %    driver folder. Press ok.
 %
 % 4. The driver will be installed from the zip file, the device manager
-%    will notifiy you of the new device, then prompt you for installation
+%    will notify you of the new device, then prompt you for installation
 %    of another device. Repeat the same procedure from step 3 until no more
 %    devices need to be installed. This procedure will repeat three to four
 %    times until all drivers are installed, as the Kinect shows up as
@@ -37,7 +37,7 @@
 %    and Kinect3DDemo for a start, then delve into your own Kinect adventures.
 %
 % The current Kinect low level drivers are still early prototypes, so
-% expect occassional bugs or weird behaviour.
+% expect occasional bugs or weird behaviour.
 %
 %
 % GNU/Linux:
@@ -67,7 +67,7 @@
 % libfreenect version 0.2 or later. Using version 0.2 or later of libfreenect
 % will also allow you to skip the following setup step 2:
 %
-% 2. Kinect is now useable from within Matlab or Octave. Well almost.
+% 2. Kinect is now usable from within Matlab or Octave. Well almost.
 % Systems with Linux kernel version 3.0 or later can use the video camera
 % and microphones of the Kinect as regular sound and video devices, e.g.,
 % for use by the Psychtoolbox videocapture and recording functions or other
@@ -82,7 +82,7 @@
 % and blindly entering your password while logged in as a user with
 % administrator rights (as the script calls the sudo command).
 %
-% 3. After this procedure, the Kinect should be fully useable by Psychtoolbox.
+% 3. After this procedure, the Kinect should be fully usable by Psychtoolbox.
 %
 %
 % Mac OS/X:
@@ -174,7 +174,7 @@ if rc == 0
     drawnow;
     [rc, msg] = system('sudo rmmod gspca_kinect');
     if rc == 0
-        fprintf('Success! Your Kinect should now be useable by Psychtoolbox PsychKinect driver.\n');
+        fprintf('Success! Your Kinect should now be usable by Psychtoolbox PsychKinect driver.\n');
     else
         fprintf('Failed! Maybe retry? Other than that, unplug your Kinect and reboot your machine to make it work.\n');
         fprintf('Reported error was: %s\n', msg);

--- a/Psychtoolbox/PsychDocumentation/KbQueue.html
+++ b/Psychtoolbox/PsychDocumentation/KbQueue.html
@@ -123,7 +123,7 @@
 		queue created by KbQueueCreate should exist when this convenience 
 		function is called. Note that a call to KbTriggerWait involves more 
 		short term overhead than a call to KbWait since the a queue must be
-		automatically created (and automaticaly destroyed) each time it is 
+		automatically created (and automatically destroyed) each time it is 
 		called.
 	</p>
 	

--- a/Psychtoolbox/PsychDocumentation/LinuxGameMode.m
+++ b/Psychtoolbox/PsychDocumentation/LinuxGameMode.m
@@ -58,7 +58,7 @@
 % system, the default card number 0 may be wrong and would need to be changed
 % manually to 1 by you.
 %
-% Note also that the default settings in the gamemode.ini file are not neccessarily
+% Note also that the default settings in the gamemode.ini file are not necessarily
 % optimal for some Intel integrated gpu's, due to the shared thermal and power budget
 % for cpu and gpu. See https://github.com/FeralInteractive/gamemode/pull/179 for
 % a detailed discussion of the problem. There is a tunable parameter, called...

--- a/Psychtoolbox/PsychDocumentation/ProceduralShadingAPI.m
+++ b/Psychtoolbox/PsychDocumentation/ProceduralShadingAPI.m
@@ -12,7 +12,7 @@
 % The shader can access that matrices/images at arbitrary texel locations.
 % This makes sense for static data - content that doesn't change, so it can
 % be encoded into the texture image matrix. Such textures or lookup tables
-% can be large, but they consume a lot of memory and bandwith.
+% can be large, but they consume a lot of memory and bandwidth.
 %
 % 2. Infrequently changing parameters: Parameters that do change, but don't
 % change too often, e.g., change only once per trial or maybe once per
@@ -30,7 +30,7 @@
 % a maximum of 16 such attributes. To keep your code portable to a variety
 % of graphics hardware, you should use this option sparingly.
 %
-% The following vertex attributes are acessible from within a vertex
+% The following vertex attributes are accessible from within a vertex
 % shader:
 %
 % Vertex attributes and their meaning, sorted by corresponding

--- a/Psychtoolbox/PsychDocumentation/ProgrammingTips.html
+++ b/Psychtoolbox/PsychDocumentation/ProgrammingTips.html
@@ -193,9 +193,9 @@ keyboard and mouse for activity, process network data packets from
 other computers, manage the virtual memory, write out data to disk
 so it doesn't get lost on a power failure or system crash. All these
 processes run in parallel to your experiment and compete for system
-ressources like memory, processor time and also ressources on your
+resources like memory, processor time and also resources on your
 graphics adaptor. If some of these processes win the race for system
-ressources shortly before the scheduled time of your stimulus onset,
+resources shortly before the scheduled time of your stimulus onset,
 it will delay execution of your code and the system will miss the
 presentation deadline, which leads to skipped frames or screwed up
 timing, finally to a spoiled trial.
@@ -234,13 +234,13 @@ to free up memory for the application that requests memory. If your
 application wakes up, it has to reclaim its data by reading it back
 from disk. This can takes multiple dozen milliseconds of time.
 </LI>
-<LI>Other applications can <I>lock</I> internal system ressources. If
-your script (or Matlab itself) happens to need these ressources, it
+<LI>Other applications can <I>lock</I> internal system resources. If
+your script (or Matlab itself) happens to need these resources, it
 will be delayed until &#34;the other application&#34; voluntarily
 releases the lock.
 </LI>
 <LI>Other applications can trigger complex graphics operations on the
-graphics hardware GPU: They steal GPU computation ressources and video
+graphics hardware GPU: They steal GPU computation resources and video
 RAM that is urgently needed by your script for stimulus drawing and
 display.
 </LI>
@@ -277,7 +277,7 @@ implemented in code written in the programming language C, that is
 executing on the computer's main processor (<I>CPU</I>), so the speed
 of drawing operations is mostly determined by the speed of your computers
 CPU. The <I>Screen</I> command of the new Psychtoolbox for OS-X (<I>PTB</I>)
-uses the plattform independent graphics library <I>OpenGL</I> for
+uses the platform independent graphics library <I>OpenGL</I> for
 all drawing operations and for control of stimulus onset. This has
 three advantages compared to the old implementations:
 
@@ -293,7 +293,7 @@ has stabilized and reached a level of maturity as the old MacOS-9
 version.
 </LI>
 <LI><I>Performance:</I> OpenGL is a 3D computer graphics API used by 3D
-applications like 3D graphics design packages, Scientifc data visualization,
+applications like 3D graphics design packages, Scientific data visualization,
 virtual reality simulators - and most importantly, as they are the
 driving market forces - video games. Most OpenGL functions are directly
 implemented in the graphics processing units (<I>GPU's</I>) of modern
@@ -447,7 +447,7 @@ The reason: If only one display shows the Psychtoolbox screen with
 your stimulus, but the other display shows the OS-X desktop with the
 Dock, the menu bar and the Matlab window as well as other applications
 windows, all these applications will consume valuable computational
-ressources and Video memory on your graphics adaptor for maintaining
+resources and Video memory on your graphics adaptor for maintaining
 and updating their displays. First they use up VRAM for their own
 framebuffers, textures and 3D data: VRAM is needed by PTB for storing
 the textures created with Screen('MakeTexture') and other temporary
@@ -459,7 +459,7 @@ for drawing of stimuli. Allocation of the drawing engine happens on
 a &#34;First come, first served&#34; bases, so you could
 be the last! Creating two onscreen windows, one on each display, or
 switching to mirror mode effectively prevents other applications than
-PTB from using ressources on the graphics hardware.
+PTB from using resources on the graphics hardware.
 </LI>
 </UL>
 If you stick to this list of configuration tips, you should get a
@@ -679,7 +679,7 @@ of other timing related functions work properly on your specific setup.
 You will see a blue screen for multiple seconds while this checks
 are performed. If a check fails or gives potentially troublesome results,
 PTB will flash a big yellow or red warning triangle on your display
-and provide a detailled trouble report on the Matlab command window,
+and provide a detailed trouble report on the Matlab command window,
 together with troubleshooting tips.
 <BR>
 On multi-display setups where the displays run at the same monitor
@@ -688,14 +688,14 @@ to make still sure that synchronization to the vertical retrace works
 properly, a perceptual test is automatically run for 10 seconds, whenever
 a multi-display setup is detected. You should see something like in
 figure TODO on your stimulus display, if syncing properly works: The
-huge gray area flickers in a homogenous way, you don't see any yellow
+huge gray area flickers in a homogeneous way, you don't see any yellow
 horizontal lines at the right border of the display, or only a few
 isolated lines, or a couple of dense yellow lines at the top of the
 display. If syncing doesn't work properly<A NAME="tex2html4"
   HREF="#foot359"><SUP>4</SUP></A>, you should instead see something like in figure TODO: Many yellow
 lines spread over the middle or bottom part of the display or even
 over the whole height of the display. The gray area is flickering
-in a very inhomogenous way - showing massive tearing artifacts. This
+in a very inhomogeneous way - showing massive tearing artifacts. This
 means that syncing to retrace is broken and you need to perform the
 troubleshooting tips that PTB outputs to the Matlab window - or set
 your displays to different refresh rates and rerun, in case PTB doesn't

--- a/Psychtoolbox/PsychDocumentation/PsychPaidSupportAndServices.m
+++ b/Psychtoolbox/PsychDocumentation/PsychPaidSupportAndServices.m
@@ -78,7 +78,7 @@ function PsychPaidSupportAndServices(mininag)
 % other words, it contributes to / acts as an insurance that allows
 % Psychtoolbox to be around and in good shape years into the future.
 %
-% To clarify: Psychtoolbox itself will stay freely downloadable and useable
+% To clarify: Psychtoolbox itself will stay freely downloadable and usable
 % by anyone, and stay fully accessible as open-source software, by anyone
 % for any purpose. Anybody able and willing to contribute code and ideas of
 % sufficiently high quality is invited to contribute to the open-source

--- a/Psychtoolbox/PsychDocumentation/RaspberryPiSetup.m
+++ b/Psychtoolbox/PsychDocumentation/RaspberryPiSetup.m
@@ -144,7 +144,7 @@
 %      will be grossly wrong, and you will observe massive tearing artifacts, flicker and
 %      other stimulus anomalies.
 %
-%   With all setup steps performed propery, and a reboot for good measure, visual
+%   With all setup steps performed properly, and a reboot for good measure, visual
 %   stimulation should work very well, with robust, trustworthy and sub-millisecond
 %   accurate visual stimulus onset timestamps, as verfied by us with external measurement
 %   equipment.

--- a/Psychtoolbox/PsychDocumentation/SyncTrouble.m
+++ b/Psychtoolbox/PsychDocumentation/SyncTrouble.m
@@ -224,8 +224,8 @@
 % 5. Graphics system overload: If you ask too much from your poor graphics
 % hardware, the system may enter a state where the electronics is not
 % capable of performing drawing operations in hardware, either because it
-% runs out of video memory ressources, or because it is lacking the
-% neccessary features. In that case, some drivers (e.g., on Microsoft
+% runs out of video memory resources, or because it is lacking the
+% necessary features. In that case, some drivers (e.g., on Microsoft
 % Windows or MacOS-X) may activate a software rendering fallback-path: The
 % graphics engine is switched off, all rendering is performed by slow
 % software in system memory on the cpu and the final image is copied to the
@@ -248,7 +248,7 @@
 % system in parallel to your Psychtoolbox+Matlab/Octave session, then these
 % applications may cause significant timing jitter in your system, so the
 % execution of Psychtoolbox - and its measurement loops - becomes
-% non-deterministic up to the point of being unuseable.
+% non-deterministic up to the point of being unusable.
 %
 % Troubleshooting: Quit and disable all applications and services not
 % needed for your study, then retry. The usual suspects are: Virus
@@ -280,7 +280,7 @@
 %
 % HOW TO OVERRIDE THE SYNC TESTS:
 %
-% That all said, there may be occassions where you do not care about
+% That all said, there may be occasions where you do not care about
 % perfect sync to retrace or millisecond accurate stimulus presentation
 % timing, but you do care about running other applications in parallel, or
 % getting your stimulus running quickly, e.g., during development and debugging
@@ -308,7 +308,7 @@
 % to 0.001, ie., 1 msec.
 %
 % 'minSamples' controls the minimum amount of valid measurements to be
-% taken for successfull tests: We require at least 50 valid samples by
+% taken for successful tests: We require at least 50 valid samples by
 % default.
 %
 % 'maxDeviation' sets a tolerance threshold for the maximum percentual
@@ -319,7 +319,7 @@
 %
 % 'maxDuration' Controls the maximum duration of a single test run in
 % seconds. We default to 5 seconds per run, with 3 repetitions if
-% neccessary. A well working system will complete the tests in less than 1
+% necessary. A well working system will complete the tests in less than 1
 % second though.
 %
 % Empirically we've found that especially Microsoft Windows may need some tweaking
@@ -366,7 +366,7 @@
 % display setups - mostly only applicable on Linux.
 %
 % MORE READING: See 'help BeampositionQueries' for more info about timing issues.
-% See 'help HybridGraphics' for problems and caveats relatd to multi-gpu machines.
+% See 'help HybridGraphics' for problems and caveats related to multi-gpu machines.
 %
 %
 % LINUX specific tips:
@@ -399,7 +399,7 @@
 % ... etc. Obviously if this happens during an experiment session, it will cause
 % the stimulation onscreen window to be be partially occluded for some time
 % by the popup, and that would temporarily impair stimulation timing and print
-% one such warning messsage for each Screen('Flip'). Try to disable the notification
+% one such warning message for each Screen('Flip'). Try to disable the notification
 % or the source of the notification popup during experiment sessions to avoid this.
 %
 % Another cause for spurious warnings like these, usually at the startup/beginning

--- a/Psychtoolbox/PsychDocumentation/VideoRecording.m
+++ b/Psychtoolbox/PsychDocumentation/VideoRecording.m
@@ -39,7 +39,7 @@
 % suitable/efficient codec, until it finds a codec that is supported on
 % your system. Not all codecs may be installed by default on your operating
 % system. Especially proprietary, non-free, or patent-encumbered codecs may
-% not be installed on your system. You may have to select them explicitely
+% not be installed on your system. You may have to select them explicitly
 % in the software center of your distribution (see "help GStreamer").
 %
 % If you only want to specify settings for the automatically chosen default
@@ -100,7 +100,7 @@
 % codec. All settings are accepted for all formats and codecs and mapped to
 % corresponding format and codec specific low level settings, or they are
 % silently ignored if a specific file/codec combination doesn't support a
-% high level setting. These settings are the most frequently choosed
+% high level setting. These settings are the most frequently chosen
 % settings.
 %
 % High level settings are specified as Keyword=value pairs, without a blank
@@ -228,7 +228,7 @@
 %
 % A specific (non-auto-selected) audio source and its settings can be
 % chosen via the 'AudioSource=' prefix, e.g., 'AudioSource=pulsesrc :::' to
-% select an audio input provided by the PulseAudio sound server explicitely.
+% select an audio input provided by the PulseAudio sound server explicitly.
 %
 % A full example string to select codecs and other low level settings would
 % look like this:

--- a/managementtools/Logonotes.txt
+++ b/managementtools/Logonotes.txt
@@ -5,7 +5,7 @@ freely redistributable for any purpose.
 version19 is the most recent version of the WelcomeSplash-upstream.ppm
 Designed in Inkscape by Celia Foster, saved as .svg
 Opened in GIMP, saved as .ppm
-The frog image is from pixabay, licence is free for commerical use,
+The frog image is from pixabay, licence is free for commercial use,
 no attribution necessary (see screenshots for details). 
 https://pixabay.com/vectors/frog-green-animal-amphibian-48234/ 
 We are told this is not Debian dfsg compliant.

--- a/managementtools/PTB-wikify-into-files.py
+++ b/managementtools/PTB-wikify-into-files.py
@@ -251,7 +251,7 @@ def beackern(mkstring, doLinks):
             mkstring = re.sub(match,r'[[\1|\1]]',mkstring)
 
         #Add links for any word using UpperCamelCase: e.g. PsychHID
-        #BUT does NOT match any string stating wiht ' e.g. 'OpenWindow'
+        #BUT does NOT match any string stating with ' e.g. 'OpenWindow'
         #Because we don't want subfunctions/strings to trigger page links
         #WARNING:
         #This is a pretty crazy regex to .  Cobled together from lots of
@@ -270,7 +270,7 @@ def beackern(mkstring, doLinks):
     mkstring = re.sub(r'(?m)((?<=\n\n).+:((?=\s*\n\n)+))', r'### \1',mkstring)
     mkstring = re.sub('(?m)((?<=\n\n)\ *[A-Z][A-Z :!-]+\ *(?=\n))', r'### \1',mkstring)
 
-    #media wiki interprets whitespace at beggining of line as code block
+    #media wiki interprets whitespace at beginning of line as code block
     if outputFormat == "mediawiki":
         mkstring = re.sub(r'^\s+','',mkstring,flags=re.M)
 
@@ -535,7 +535,7 @@ def mexhelpextract(outputDir,mexnames):
             if seealso:
 
                 #Add links for any word using UpperCamelCase: e.g. PsychHID
-                #BUT does NOT match any string stating wiht ' e.g. 'OpenWindow'
+                #BUT does NOT match any string stating with ' e.g. 'OpenWindow'
                 #Because we don't want subfunctions/strings to trigger page links
                 #WARNING:
                 #This is a pretty crazy regex to .  Cobled together from lots of

--- a/managementtools/PTB-wikify.py
+++ b/managementtools/PTB-wikify.py
@@ -382,7 +382,7 @@ def mexhelpextract(mexnames):
                 # replace the text of the container DIV
                 subfct.contents[0].replaceWith(text)
             else:
-                # contruct new DIV to hold the text
+                # construct new DIV to hold the text
                 subfctDIV = Tag(soup, "div")
                 subfctDIV['class'] = 'subfct'
                 subfctDIV['id'] = mexname

--- a/managementtools/parseptblog.php
+++ b/managementtools/parseptblog.php
@@ -15,7 +15,7 @@
 // History:
 // 10/20/2006 Written. (MK)
 // 11/03/2006 * Made more robust against corrupted lines in logfile.
-//            * More detailled stats: Show distribution of Macintoshes.
+//            * More detailed stats: Show distribution of Macintoshes.
 //            * Improved HTML output formatting.
 // 20/05/2018 * Rewritten to parse the fully anonymized final log.
 


### PR DESCRIPTION
This patch restricts itself to the following folders and fixes 54 out of 3552 reported typos (some of which might be false positives of course):
* `Psychtoolbox/PsychDocumentation`
* `managementtools`

Would you be willing to accept further fixes of typos found by [codespell](https://github.com/codespell-project/codespell)?