### PR TITLE
Property will not work properly, as class Stream is an old-style class

### DIFF
--- a/PsychPython/psychtoolbox/audio.py
+++ b/PsychPython/psychtoolbox/audio.py
@@ -84,7 +84,7 @@ def tune_engine(yield_interval, mutex_enable, lock_to_core1,
                           lock_to_core1, audioserver_autosuspend)
 
 
-class Stream():
+class Stream:
     """
     Creates a Psychtoolbox Stream with the given settings.
     See also http://psychtoolbox.org/docs/PsychPortAudio-Open
@@ -236,7 +236,7 @@ class Stream():
         self.close()
 
 
-class Buffer():
+class Buffer:
     """A buffer allows us to pre-fill a Stream or a Slave with data ready
     to be played. It can be created and filled in a single operation or can
     be created and then filled in two steps."""

--- a/PsychPython/psychtoolbox/hid.py
+++ b/PsychPython/psychtoolbox/hid.py
@@ -121,7 +121,7 @@ class Device:
         return PsychHID('ReceiveReportsStop', self.device_number)
 
 
-class Keyboard():
+class Keyboard:
     def __init__(self, device_number=None, buffer_size=10000):
         """A Keyboard object is like a Device() with key-specific functions
 


### PR DESCRIPTION
This is an error reported by LGTM.com:
https://lgtm.com/projects/g/kleinerm/Psychtoolbox-3/?severity=error

I'm not certain whether Psychtoolbox still supports Python 2 or only Python 3. Either way:
* In Python 2 both class `OldStyle` and class `OldStyle()` define "old-style" classes and `@property` requires new-style classes.
* Python 3 provides "new-style" classes only, so if only Python 3 is supported, this would be a false positive. I believe using Python 3 definitions (without parenthesis for inheritance) will make clear this a Python 3 definition and the alert will disappear.