### PR TITLE
Use getenv('HOME') when code is deployed

### DIFF
--- a/Psychtoolbox/PsychFiles/PsychtoolboxConfigDir.m
+++ b/Psychtoolbox/PsychFiles/PsychtoolboxConfigDir.m
@@ -41,13 +41,22 @@ if isempty(ThePath)
         % commands below will expand '~/' to a full path; echoing the HOME
         % environment variable was the first way I found to get said full path so
         % that strings will match when they should
-        [ErrMsg,HomeDir] = unix('echo $HOME');
-        % end-1 to trim trailing carriage return
-        StringStart = [HomeDir(1:(end-1)) '/Library/Preferences/'];
+		if ~isdeployed
+			[ErrMsg,HomeDir] = unix('echo $HOME');
+			HomeDir = HomeDir(1:(end-1)); % end-1 to trim trailing carriage return
+		else
+			HomeDir = getenv('HOME');
+		end
+        StringStart = [HomeDir '/Library/Preferences/'];
+		
     elseif IsLinux
-        [ErrMsg,HomeDir] = unix('echo $HOME');
-        % end-1 to trim trailing carriage return
-        StringStart = [HomeDir(1:(end-1)) '/.'];
+		if ~isdeployed
+			[ErrMsg,HomeDir] = unix('echo $HOME');
+			HomeDir = HomeDir(1:(end-1)); % end-1 to trim trailing carriage return
+		else
+			HomeDir = getenv('HOME');
+		end
+        StringStart = [HomeDir '/.'];
     elseif IsWindows
         [ErrMsg,StringStart] = dos('echo %AppData%');
         StringStart = deblank(StringStart);

--- a/Psychtoolbox/PsychOpenGL/MOGL/source/glew.c
+++ b/Psychtoolbox/PsychOpenGL/MOGL/source/glew.c
@@ -18338,7 +18338,7 @@ GLboolean eglewGetExtension (const char* name)
   start = (const GLubyte*) eglQueryString(eglGetCurrentDisplay(), EGL_EXTENSIONS);
   if (0 == start) return GL_FALSE;
   end = start + _glewStrLen(start);
-  return _glewSearchExtension(name, start, end);
+  return _glewSearchExtension(name, startidx, endidx);
 }
 
 GLenum eglewInit (EGLDisplay display)
@@ -19521,7 +19521,7 @@ GLboolean GLEWAPIENTRY wglewGetExtension (const char* name)
   if (start == 0)
     return GL_FALSE;
   end = start + _glewStrLen(start);
-  return _glewSearchExtension(name, start, end);
+  return _glewSearchExtension(name, startidx, endidx);
 }
 
 GLenum GLEWAPIENTRY wglewInit ()
@@ -20530,7 +20530,7 @@ GLboolean glxewGetExtension (const char* name)
   start = (const GLubyte*)glXGetClientString(glXGetCurrentDisplay(), GLX_EXTENSIONS);
   if (0 == start) return GL_FALSE;
   end = start + _glewStrLen(start);
-  return _glewSearchExtension(name, start, end);
+  return _glewSearchExtension(name, startidx, endidx);
 }
 
 GLenum glxewInit ()

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/_glGetBufferSubDataARB.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/_glGetBufferSubDataARB.m
@@ -1,8 +1,8 @@
-function data = glGetBufferSubDataARB( target, ARB, ARB )
+function data = glGetBufferSubDataARB( target, ARB1, ARB2 )
 
 % glGetBufferSubDataARB  Interface to OpenGL function glGetBufferSubDataARB
 %
-% usage:  data = glGetBufferSubDataARB( target, ARB, ARB )
+% usage:  data = glGetBufferSubDataARB( target, ARB1, ARB2 )
 %
 % C function:  void glGetBufferSubDataARB(GLenum target, GLintptr ARB, GLsizeiptr ARB, void* data)
 
@@ -16,6 +16,6 @@ end
 
 data = (0);
 
-moglcore( 'glGetBufferSubDataARB', target, ARB, ARB, data );
+moglcore( 'glGetBufferSubDataARB', target, ARB1, ARB2, data );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glBufferSubDataARB.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glBufferSubDataARB.m
@@ -1,8 +1,8 @@
-function glBufferSubDataARB( target, ARB, ARB, data )
+function glBufferSubDataARB( target, ARB1, ARB2, data )
 
 % glBufferSubDataARB  Interface to OpenGL function glBufferSubDataARB
 %
-% usage:  glBufferSubDataARB( target, ARB, ARB, data )
+% usage:  glBufferSubDataARB( target, ARB1, ARB2, data )
 %
 % C function:  void glBufferSubDataARB(GLenum target, GLintptr ARB, GLsizeiptr ARB, const void* data)
 
@@ -12,6 +12,6 @@ if nargin~=4,
     error('invalid number of arguments');
 end
 
-moglcore( 'glBufferSubDataARB', target, ARB, ARB, data );
+moglcore( 'glBufferSubDataARB', target, ARB1, ARB2, data );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glClearBufferSubData.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glClearBufferSubData.m
@@ -1,8 +1,8 @@
-function glClearBufferSubData( target, internalformat, ptr, ptr, format, type, data )
+function glClearBufferSubData( target, internalformat, ptr1, ptr2, format, type, data )
 
 % glClearBufferSubData  Interface to OpenGL function glClearBufferSubData
 %
-% usage:  glClearBufferSubData( target, internalformat, ptr, ptr, format, type, data )
+% usage:  glClearBufferSubData( target, internalformat, ptr1, ptr2, format, type, data )
 %
 % C function:  void glClearBufferSubData(GLenum target, GLenum internalformat, GLint ptr, GLsizei ptr, GLenum format, GLenum type, const void* data)
 
@@ -12,6 +12,6 @@ if nargin~=7,
     error('invalid number of arguments');
 end
 
-moglcore( 'glClearBufferSubData', target, internalformat, ptr, ptr, format, type, data );
+moglcore( 'glClearBufferSubData', target, internalformat, ptr1, ptr2, format, type, data );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glClearNamedBufferSubDataEXT.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glClearNamedBufferSubDataEXT.m
@@ -1,8 +1,8 @@
-function glClearNamedBufferSubDataEXT( buffer, internalformat, format, type, ptr, ptr, data )
+function glClearNamedBufferSubDataEXT( buffer, internalformat, format, type, ptr1, ptr2, data )
 
 % glClearNamedBufferSubDataEXT  Interface to OpenGL function glClearNamedBufferSubDataEXT
 %
-% usage:  glClearNamedBufferSubDataEXT( buffer, internalformat, format, type, ptr, ptr, data )
+% usage:  glClearNamedBufferSubDataEXT( buffer, internalformat, format, type, ptr1, ptr2, data )
 %
 % C function:  void glClearNamedBufferSubDataEXT(GLuint buffer, GLenum internalformat, GLenum format, GLenum type, GLsizei ptr, GLsizei ptr, const void* data)
 
@@ -12,6 +12,6 @@ if nargin~=7,
     error('invalid number of arguments');
 end
 
-moglcore( 'glClearNamedBufferSubDataEXT', buffer, internalformat, format, type, ptr, ptr, data );
+moglcore( 'glClearNamedBufferSubDataEXT', buffer, internalformat, format, type, ptr1, ptr2, data );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glCopyBufferSubData.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glCopyBufferSubData.m
@@ -1,8 +1,8 @@
-function glCopyBufferSubData( readTarget, writeTarget, ptr, ptr, ptr )
+function glCopyBufferSubData( readTarget, writeTarget, ptr1, ptr2, ptr )
 
 % glCopyBufferSubData  Interface to OpenGL function glCopyBufferSubData
 %
-% usage:  glCopyBufferSubData( readTarget, writeTarget, ptr, ptr, ptr )
+% usage:  glCopyBufferSubData( readTarget, writeTarget, ptr1, ptr2, ptr )
 %
 % C function:  void glCopyBufferSubData(GLenum readTarget, GLenum writeTarget, GLint ptr, GLint ptr, GLsizei ptr)
 
@@ -12,6 +12,6 @@ if nargin~=5,
     error('invalid number of arguments');
 end
 
-moglcore( 'glCopyBufferSubData', readTarget, writeTarget, ptr, ptr, ptr );
+moglcore( 'glCopyBufferSubData', readTarget, writeTarget, ptr1, ptr2, ptr );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElementArrayAPPLE.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElementArrayAPPLE.m
@@ -1,8 +1,8 @@
-function glDrawRangeElementArrayAPPLE( mode, start, end, first, count )
+function glDrawRangeElementArrayAPPLE( mode, startidx, endidx, first, count )
 
 % glDrawRangeElementArrayAPPLE  Interface to OpenGL function glDrawRangeElementArrayAPPLE
 %
-% usage:  glDrawRangeElementArrayAPPLE( mode, start, end, first, count )
+% usage:  glDrawRangeElementArrayAPPLE( mode, startidx, endidx, first, count )
 %
 % C function:  void glDrawRangeElementArrayAPPLE(GLenum mode, GLuint start, GLuint end, GLint first, GLsizei count)
 
@@ -12,6 +12,6 @@ if nargin~=5,
     error('invalid number of arguments');
 end
 
-moglcore( 'glDrawRangeElementArrayAPPLE', mode, start, end, first, count );
+moglcore( 'glDrawRangeElementArrayAPPLE', mode, startidx, endidx, first, count );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElementArrayATI.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElementArrayATI.m
@@ -1,8 +1,8 @@
-function glDrawRangeElementArrayATI( mode, start, end, count )
+function glDrawRangeElementArrayATI( mode, startidx, endidx, count )
 
 % glDrawRangeElementArrayATI  Interface to OpenGL function glDrawRangeElementArrayATI
 %
-% usage:  glDrawRangeElementArrayATI( mode, start, end, count )
+% usage:  glDrawRangeElementArrayATI( mode, startidx, endidx, count )
 %
 % C function:  void glDrawRangeElementArrayATI(GLenum mode, GLuint start, GLuint end, GLsizei count)
 
@@ -12,6 +12,6 @@ if nargin~=4,
     error('invalid number of arguments');
 end
 
-moglcore( 'glDrawRangeElementArrayATI', mode, start, end, count );
+moglcore( 'glDrawRangeElementArrayATI', mode, startidx, endidx, count );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElements.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElements.m
@@ -1,8 +1,8 @@
-function glDrawRangeElements( mode, start, endidx, count, type, indices )
+function glDrawRangeElements( mode, startidx, endidx, count, type, indices )
 
 % glDrawRangeElements  Interface to OpenGL function glDrawRangeElements
 %
-% usage:  glDrawRangeElements( mode, start, endidx, count, type, indices )
+% usage:  glDrawRangeElements( mode, startidx, endidx, count, type, indices )
 %
 % C function:  void glDrawRangeElements(GLenum mode, GLuint start, GLuint endidx, GLsizei count, GLenum type, const GLvoid* indices)
 
@@ -14,6 +14,6 @@ if nargin~=6,
     error('invalid number of arguments');
 end
 
-moglcore( 'glDrawRangeElements', mode, start, endidx, count, type, indices );
+moglcore( 'glDrawRangeElements', mode, startidx, endidx, count, type, indices );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElementsBaseVertex.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElementsBaseVertex.m
@@ -1,8 +1,8 @@
-function glDrawRangeElementsBaseVertex( mode, start, end, count, type, indices, basevertex )
+function glDrawRangeElementsBaseVertex( mode, startidx, endidx, count, type, indices, basevertex )
 
 % glDrawRangeElementsBaseVertex  Interface to OpenGL function glDrawRangeElementsBaseVertex
 %
-% usage:  glDrawRangeElementsBaseVertex( mode, start, end, count, type, indices, basevertex )
+% usage:  glDrawRangeElementsBaseVertex( mode, startidx, endidx, count, type, indices, basevertex )
 %
 % C function:  void glDrawRangeElementsBaseVertex(GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const GLvoid* indices, GLint basevertex)
 
@@ -12,6 +12,6 @@ if nargin~=7,
     error('invalid number of arguments');
 end
 
-moglcore( 'glDrawRangeElementsBaseVertex', mode, start, end, count, type, indices, basevertex );
+moglcore( 'glDrawRangeElementsBaseVertex', mode, startidx, endidx, count, type, indices, basevertex );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElementsEXT.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glDrawRangeElementsEXT.m
@@ -1,8 +1,8 @@
-function glDrawRangeElementsEXT( mode, start, end, count, type, indices )
+function glDrawRangeElementsEXT( mode, startidx, endidx, count, type, indices )
 
 % glDrawRangeElementsEXT  Interface to OpenGL function glDrawRangeElementsEXT
 %
-% usage:  glDrawRangeElementsEXT( mode, start, end, count, type, indices )
+% usage:  glDrawRangeElementsEXT( mode, startidx, endidx, count, type, indices )
 %
 % C function:  void glDrawRangeElementsEXT(GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const void* indices)
 
@@ -12,6 +12,6 @@ if nargin~=6,
     error('invalid number of arguments');
 end
 
-moglcore( 'glDrawRangeElementsEXT', mode, start, end, count, type, indices );
+moglcore( 'glDrawRangeElementsEXT', mode, startidx, endidx, count, type, indices );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glFlushMappedBufferRange.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glFlushMappedBufferRange.m
@@ -1,8 +1,8 @@
-function glFlushMappedBufferRange( target, ptr, ptr )
+function glFlushMappedBufferRange( target, ptr1, ptr2 )
 
 % glFlushMappedBufferRange  Interface to OpenGL function glFlushMappedBufferRange
 %
-% usage:  glFlushMappedBufferRange( target, ptr, ptr )
+% usage:  glFlushMappedBufferRange( target, ptr1, ptr2 )
 %
 % C function:  void glFlushMappedBufferRange(GLenum target, GLint ptr, GLsizei ptr)
 
@@ -12,6 +12,6 @@ if nargin~=3,
     error('invalid number of arguments');
 end
 
-moglcore( 'glFlushMappedBufferRange', target, ptr, ptr );
+moglcore( 'glFlushMappedBufferRange', target, ptr1, ptr2 );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glInvalidateBufferSubData.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glInvalidateBufferSubData.m
@@ -1,8 +1,8 @@
-function glInvalidateBufferSubData( buffer, ptr, ptr )
+function glInvalidateBufferSubData( buffer, ptr1, ptr2 )
 
 % glInvalidateBufferSubData  Interface to OpenGL function glInvalidateBufferSubData
 %
-% usage:  glInvalidateBufferSubData( buffer, ptr, ptr )
+% usage:  glInvalidateBufferSubData( buffer, ptr1, ptr2 )
 %
 % C function:  void glInvalidateBufferSubData(GLuint buffer, GLint ptr, GLsizei ptr)
 
@@ -12,6 +12,6 @@ if nargin~=3,
     error('invalid number of arguments');
 end
 
-moglcore( 'glInvalidateBufferSubData', buffer, ptr, ptr );
+moglcore( 'glInvalidateBufferSubData', buffer, ptr1, ptr2 );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glMapBufferRange.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glMapBufferRange.m
@@ -1,8 +1,8 @@
-function r = glMapBufferRange( target, ptr, ptr, access )
+function r = glMapBufferRange( target, ptr1, ptr2, access )
 
 % glMapBufferRange  Interface to OpenGL function glMapBufferRange
 %
-% usage:  r = glMapBufferRange( target, ptr, ptr, access )
+% usage:  r = glMapBufferRange( target, ptr1, ptr2, access )
 %
 % C function:  GLvoid* glMapBufferRange(GLenum target, GLint ptr, GLsizei ptr, GLbitfield access)
 
@@ -12,6 +12,6 @@ if nargin~=4,
     error('invalid number of arguments');
 end
 
-r = moglcore( 'glMapBufferRange', target, ptr, ptr, access );
+r = moglcore( 'glMapBufferRange', target, ptr1, ptr2, access );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glMultiDrawRangeElementArrayAPPLE.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glMultiDrawRangeElementArrayAPPLE.m
@@ -1,8 +1,8 @@
-function glMultiDrawRangeElementArrayAPPLE( mode, start, end, first, count, primcount )
+function glMultiDrawRangeElementArrayAPPLE( mode, startidx, endidx, first, count, primcount )
 
 % glMultiDrawRangeElementArrayAPPLE  Interface to OpenGL function glMultiDrawRangeElementArrayAPPLE
 %
-% usage:  glMultiDrawRangeElementArrayAPPLE( mode, start, end, first, count, primcount )
+% usage:  glMultiDrawRangeElementArrayAPPLE( mode, startidx, endidx, first, count, primcount )
 %
 % C function:  void glMultiDrawRangeElementArrayAPPLE(GLenum mode, GLuint start, GLuint end, const GLint* first, const GLsizei* count, GLsizei primcount)
 
@@ -12,6 +12,6 @@ if nargin~=6,
     error('invalid number of arguments');
 end
 
-moglcore( 'glMultiDrawRangeElementArrayAPPLE', mode, start, end, int32(first), int32(count), primcount );
+moglcore( 'glMultiDrawRangeElementArrayAPPLE', mode, startidx, endidx, int32(first), int32(count), primcount );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glTexBufferRange.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glTexBufferRange.m
@@ -1,8 +1,8 @@
-function glTexBufferRange( target, internalformat, buffer, ptr, ptr )
+function glTexBufferRange( target, internalformat, buffer, ptr1, ptr2 )
 
 % glTexBufferRange  Interface to OpenGL function glTexBufferRange
 %
-% usage:  glTexBufferRange( target, internalformat, buffer, ptr, ptr )
+% usage:  glTexBufferRange( target, internalformat, buffer, ptr1, ptr2 )
 %
 % C function:  void glTexBufferRange(GLenum target, GLenum internalformat, GLuint buffer, GLint ptr, GLsizei ptr)
 
@@ -12,6 +12,6 @@ if nargin~=5,
     error('invalid number of arguments');
 end
 
-moglcore( 'glTexBufferRange', target, internalformat, buffer, ptr, ptr );
+moglcore( 'glTexBufferRange', target, internalformat, buffer, ptr1, ptr2 );
 
 return

--- a/Psychtoolbox/PsychOpenGL/MOGL/wrap/glTextureBufferRangeEXT.m
+++ b/Psychtoolbox/PsychOpenGL/MOGL/wrap/glTextureBufferRangeEXT.m
@@ -1,8 +1,8 @@
-function glTextureBufferRangeEXT( texture, target, internalformat, buffer, ptr, ptr )
+function glTextureBufferRangeEXT( texture, target, internalformat, buffer, ptr1, ptr2 )
 
 % glTextureBufferRangeEXT  Interface to OpenGL function glTextureBufferRangeEXT
 %
-% usage:  glTextureBufferRangeEXT( texture, target, internalformat, buffer, ptr, ptr )
+% usage:  glTextureBufferRangeEXT( texture, target, internalformat, buffer, ptr1, ptr2 )
 %
 % C function:  void glTextureBufferRangeEXT(GLuint texture, GLenum target, GLenum internalformat, GLuint buffer, GLint ptr, GLsizei ptr)
 
@@ -12,6 +12,6 @@ if nargin~=6,
     error('invalid number of arguments');
 end
 
-moglcore( 'glTextureBufferRangeEXT', texture, target, internalformat, buffer, ptr, ptr );
+moglcore( 'glTextureBufferRangeEXT', texture, target, internalformat, buffer, ptr1, ptr2 );
 
 return


### PR DESCRIPTION
For some reason `unix('echo $HOME')` causes compilation errors when code is compiled with MATLAB compiler (at least on my macOS laptop). `getenv('HOME')` does work and so using the command `isdeployed` can switch between the previous code and `getenv`. I'm not sure why this code captures a shell command as `getenv` has been around for ages and is also supported by Octave: https://octave.org/doc/v6.4.0/Environment-Variables.html#Environment-Variables — another option would be to just use getenv whether deployed or not...