### PR TITLE
using $HOME causes errors in MATLAB compiler

### DIFF
--- a/Psychtoolbox/PsychFiles/PsychtoolboxConfigDir.m
+++ b/Psychtoolbox/PsychFiles/PsychtoolboxConfigDir.m
@@ -41,13 +41,22 @@ if isempty(ThePath)
         % commands below will expand '~/' to a full path; echoing the HOME
         % environment variable was the first way I found to get said full path so
         % that strings will match when they should
-        [ErrMsg,HomeDir] = unix('echo $HOME');
-        % end-1 to trim trailing carriage return
-        StringStart = [HomeDir(1:(end-1)) '/Library/Preferences/'];
+		if ~isdeployed
+			[ErrMsg,HomeDir] = unix('echo $HOME');
+			HomeDir = HomeDir(1:(end-1)); % end-1 to trim trailing carriage return
+		else
+			HomeDir = getenv('HOME');
+		end
+        StringStart = [HomeDir '/Library/Preferences/'];
+		
     elseif IsLinux
-        [ErrMsg,HomeDir] = unix('echo $HOME');
-        % end-1 to trim trailing carriage return
-        StringStart = [HomeDir(1:(end-1)) '/.'];
+		if ~isdeployed
+			[ErrMsg,HomeDir] = unix('echo $HOME');
+			HomeDir = HomeDir(1:(end-1)); % end-1 to trim trailing carriage return
+		else
+			HomeDir = getenv('HOME');
+		end
+        StringStart = [HomeDir '/.'];
     elseif IsWindows
         [ErrMsg,StringStart] = dos('echo %AppData%');
         StringStart = deblank(StringStart);


### PR DESCRIPTION
For some reason unix('echo $HOME') causes compilation errors when code is compiled with MATLAB compiler (at least on my macOS laptop). getenv('HOME') does work and so using the command isdeployed can switch between the previous code and getenv. I'm not sure why this code captures a shell command as getenv has been around for ages and is also supported by Octave: https://octave.org/doc/v6.4.0/Environment-Variables.html#Environment-Variables — another option would be to just use getenv whether deployed or not...