### PR TITLE
PsychtoolboxConfigDir(): Use getenv('HOME') to retrieve home directory instead of unix('echo $HOME')

### DIFF
--- a/Psychtoolbox/PsychFiles/PsychtoolboxConfigDir.m
+++ b/Psychtoolbox/PsychFiles/PsychtoolboxConfigDir.m
@@ -41,13 +41,11 @@ if isempty(ThePath)
         % commands below will expand '~/' to a full path; echoing the HOME
         % environment variable was the first way I found to get said full path so
         % that strings will match when they should
-        [ErrMsg,HomeDir] = unix('echo $HOME');
-        % end-1 to trim trailing carriage return
-        StringStart = [HomeDir(1:(end-1)) '/Library/Preferences/'];
+        HomeDir = getenv('HOME');
+        StringStart = [HomeDir '/Library/Preferences/'];
     elseif IsLinux
-        [ErrMsg,HomeDir] = unix('echo $HOME');
-        % end-1 to trim trailing carriage return
-        StringStart = [HomeDir(1:(end-1)) '/.'];
+        HomeDir = getenv('HOME');
+        StringStart = [HomeDir '/.'];
     elseif IsWindows
         [ErrMsg,StringStart] = dos('echo %AppData%');
         StringStart = deblank(StringStart);


### PR DESCRIPTION
This change is due to a MATLAB Compiler error due to the use of
`unix('echo $HOME')` whereas `getenv('HOME')` compiles OK (only tested on macOS so
far) -- note that both MATLAB and Octave support the use of `getenv()`. Once compiled and run, `getenv('HOME')` correctly retrieves the user's home dir just fine...

This is simplified from the previous pull #219 (no need to use `isdeployed`) with a more descriptive title (hope it's OK)...