### PR TITLE
AssertOpenGL(): Do not use Wayland backend by default.

### DIFF
--- a/Psychtoolbox/PsychOneliners/AssertOpenGL.m
+++ b/Psychtoolbox/PsychOneliners/AssertOpenGL.m
@@ -85,7 +85,7 @@ try
     oneTimeDone = 1;
 
     % Wayland desktop on 64-Bit Linux with Octave?
-    if IsLinux(1) && IsOctave && IsWayland
+    if IsLinux(1) && IsOctave && IsWayland && ~isempty(getenv('PSYCH_ALLOW_WAYLAND'))
         % Add path, so our Wayland build of Screen.mex overrides the standard one:
         rdir = [PsychtoolboxRoot 'PsychBasic/Octave5LinuxFiles64/Wayland'];
         if exist(rdir, 'dir')


### PR DESCRIPTION
Only use it if user opted in via setenv('PSYCH_ALLOW_WAYLAND', '1').

Use by default on Octave + Linux was a bad idea, as it would expose users who logged into a
Wayland session accidentally to a half-finished backend on a unsuitable display server. This
would happen, e.g., to all Ubuntu 22.04-LTS users by default if they used Octave!