### PR TITLE
Python fixes for weakly linking libusb & compiler detection

### DIFF
--- a/PsychSourceGL/Source/Common/Base/PythonGlue/PsychScriptingGluePython.c
+++ b/PsychSourceGL/Source/Common/Base/PythonGlue/PsychScriptingGluePython.c
@@ -55,7 +55,7 @@
 #define NPY_NO_DEPRECATED_API NPY_1_13_API_VERSION
 #include <numpy/arrayobject.h>
 
-#if defined(Py_LIMITED_API) && defined(__GNUC__) && (__GNUC__ < 10)
+#if defined(Py_LIMITED_API) && defined(__GNUC__) && (__GNUC__ < 10) && !defined(__clang__)
 #error \
 "This version of gcc has a bug and cannot compile this code \
 with Py_LIMITED_API enabled. Either build without Py_LIMITED_API \

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,7 @@ if platform.system() == 'Darwin':
     psychhid_libs = []
     # Weak-link libusb-1.0.dylib, so user does not need it on their local system as long as they
     # don't use PsychHID functions like USBControlTransfer/USBInterruptTransfer/USBBulkTransfer:
-    psychhid_extralinkargs = ['-weak_library PsychSourceGL/Cohorts/libusb1-win32/libusb-1.0.dylib']
+    psychhid_extralinkargs = ['-weak_library', 'PsychSourceGL/Cohorts/libusb1-win32/libusb-1.0.dylib']
 
     # Extra objects for PsychHID - statically linked HID utilities:
     psychhid_extra_objects = ['PsychSourceGL/Cohorts/HID_Utilities_64Bit/build/Release/libHID_Utilities64.a']


### PR DESCRIPTION
Hi Mario,

I'm cautiously optimistic this fixes the weak linking of libusb introduced in 26ebaae94b4dfb481fa3a928931d80dfa138d646 (all of the "real" Macs I have access to walked away for the day before I got to test). Here's what the original commit gave me: 

https://github.com/aforren1/ptb-wheels/actions/runs/4116377822/jobs/7106352950#step:5:486

and here's one of the successful ones following the change:

https://github.com/aforren1/ptb-wheels/actions/runs/4118809478/jobs/7111777645#step:5:1146

I should get to test locally sometime tomorrow? If you wanted to peek at the wheels, they're all available under the "Artifacts" section here: https://github.com/aforren1/ptb-wheels/actions/runs/4118809478

I also worked in a fix for GCC-related detection, which would incorrectly error if Clang was the selected compiler.

Re: existing USB interfaces in Python, I've only ever used [pyusb](https://github.com/pyusb/pyusb), which IIRC expects the user to provide the shared library. I think it would be fine to distribute libusb-- it's small enough, and might head off user reports in the future? I think PsychoPy is the largest consumer of the Psychtoolbox python package, so maybe @peircej has a preference?