### PR TITLE
Python: include Windows & Mac build- and run-time dependencies in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,14 @@ include README
 include PsychSourceGL/License.txt
 recursive-include PsychSourceGL *.c
 recursive-include PsychSourceGL *.h
+
+# Windows dependencies
+include PsychSourceGL/Cohorts/libusb1-win32/MS32/dll/libusb-1.0.*
+include PsychSourceGL/Cohorts/libusb1-win32/MS64/dll/libusb-1.0.*
+include Psychtoolbox/PsychSound/portaudio_x64.dll
+include PsychSourceGL/Cohorts/PortAudio/portaudio_x64.lib
+
+# macOS dependencies
+include PsychSourceGL/Cohorts/libusb1-win32/libusb-1.0.dylib
+include PsychSourceGL/Cohorts/HID_Utilities_64Bit/build/Release/libHID_Utilities64.a
+include PsychSourceGL/Cohorts/PortAudio/libportaudio_osx_64.a


### PR DESCRIPTION
This change tells Python to include the necessary shared & static libraries for building PsychPortAudio/PsychHID in the source archive. If the entrepreneurial user tried to install from source instead of relying on one of the pre-built wheels, the build step would fail due to these missing dependencies.

I now test building from the source archive on Linux/Win/Mac, and appears successful (see e.g. [here](https://github.com/aforren1/ptb-wheels/actions/runs/4448339211)).

Originally reported by Ian [here](https://psychtoolbox.discourse.group/t/libusb-and-the-psychtoolbox-wheel-in-psychopy/4883).