### PR TITLE
Updates to the GH Action for building and releasing zip/ MLTBX artifacts

### DIFF
--- a/.github/workflows/buildZipMLTBX.yml
+++ b/.github/workflows/buildZipMLTBX.yml
@@ -4,9 +4,12 @@ name: Tag triggered release
 
 # # Start the workflow when a tag is created.
 on:
-  push:
-    tags:
-      - '*'
+  # push:
+  #   tags:
+  #     - '*'
+  workflow_dispatch:
+
+
 
 # A workflow run consists of jobs that run sequentially
 jobs:

--- a/.github/workflows/buildZipMLTBXReleaseDriven.yml
+++ b/.github/workflows/buildZipMLTBXReleaseDriven.yml
@@ -2,7 +2,7 @@
 
 name: Update a published release with build artifacts
 
-# Start the workflow when a draft release is created.
+# Start the workflow when a release is published.
 on:
   release:
     types: [published]
@@ -43,12 +43,3 @@ jobs:
       # # This is for diagnostics
       # - name: list directories
       #   run: ls -l
-
-      # Create the release
-      # - name: Create release
-      #   uses: ncipollo/release-action@v1
-      #   with:
-      #     draft: true
-      #     artifacts: "./${{  github.ref_name }}.zip, ./${{  github.ref_name }}.mltbx"
-      #     generateReleaseNotes: true
-      #     tag: ${{  github.ref_name }}

--- a/.github/workflows/buildZipMLTBXReleaseDriven.yml
+++ b/.github/workflows/buildZipMLTBXReleaseDriven.yml
@@ -1,6 +1,6 @@
 # This is a GitHub Action workflow to build toolbox zip/ MLTBX and upload it to a GitHub release
 
-name: Workflow to update a draft release with build artifacts
+name: Update a published release with build artifacts
 
 # Start the workflow when a draft release is created.
 on:
@@ -10,7 +10,7 @@ on:
 # A workflow run consists of jobs that run sequentially
 jobs:
   # This workflow contains one job that builds the zip and MLTBX files.
-  releaseUserFiles:
+  AttachBuildArtifacts:
     # The type of runner that the job will run on, we use latest Ubuntu
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/buildZipMLTBXReleaseDriven.yml
+++ b/.github/workflows/buildZipMLTBXReleaseDriven.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload artifacts to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run:
+        run: |
           gh release upload "${{  github.ref_name }}" "./${{  github.ref_name }}.mltbx"
           gh release upload "${{  github.ref_name }}" "./${{  github.ref_name }}.zip"
     

--- a/.github/workflows/buildZipMLTBXReleaseDriven.yml
+++ b/.github/workflows/buildZipMLTBXReleaseDriven.yml
@@ -31,15 +31,24 @@ jobs:
         with:
           command: addpath([pwd filesep 'managementtools']); createPsychtoolboxMLTBX("Psychtoolbox.prj",  "${{  github.ref_name }}")
 
+      - name: Upload artifacts to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          gh release upload "${{  github.ref_name }}" "./${{  github.ref_name }}.mltbx"
+          gh release upload "${{  github.ref_name }}" "./${{  github.ref_name }}.zip"
+    
+
+
       # # This is for diagnostics
       # - name: list directories
       #   run: ls -l
 
       # Create the release
-      - name: Create release
-        uses: ncipollo/release-action@v1
-        with:
-          draft: true
-          artifacts: "./${{  github.ref_name }}.zip, ./${{  github.ref_name }}.mltbx"
-          generateReleaseNotes: true
-          tag: ${{  github.ref_name }}
+      # - name: Create release
+      #   uses: ncipollo/release-action@v1
+      #   with:
+      #     draft: true
+      #     artifacts: "./${{  github.ref_name }}.zip, ./${{  github.ref_name }}.mltbx"
+      #     generateReleaseNotes: true
+      #     tag: ${{  github.ref_name }}

--- a/.github/workflows/buildZipMLTBXReleaseDriven.yml
+++ b/.github/workflows/buildZipMLTBXReleaseDriven.yml
@@ -1,8 +1,8 @@
 # This is a GitHub Action workflow to build toolbox zip/ MLTBX and upload it to a GitHub release
 
-name: Workflow to update a release with artifacts
+name: Workflow to update a draft release with build artifacts
 
-# Start the workflow when a tag is created.
+# Start the workflow when a draft release is created.
 on:
   release:
     types: [published]

--- a/.github/workflows/buildZipMLTBXReleaseDriven.yml
+++ b/.github/workflows/buildZipMLTBXReleaseDriven.yml
@@ -1,0 +1,45 @@
+# This is a GitHub Action workflow to build toolbox zip/ MLTBX and upload it to a GitHub release
+
+name: Workflow to update a release with artifacts
+
+# Start the workflow when a tag is created.
+on:
+  release:
+    types: [published]
+
+# A workflow run consists of jobs that run sequentially
+jobs:
+  # This workflow contains one job that builds the zip and MLTBX files.
+  releaseUserFiles:
+    # The type of runner that the job will run on, we use latest Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      # Runs commands using the runners shell
+      - name: checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Zip the toolbox
+        run: zip -r '${{  github.ref_name }}.zip' Psychtoolbox
+
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v1
+
+      - name: Create MLTBX
+        uses: matlab-actions/run-command@v1
+        continue-on-error: false
+        if: always()
+        with:
+          command: addpath([pwd filesep 'managementtools']); createPsychtoolboxMLTBX("Psychtoolbox.prj",  "${{  github.ref_name }}")
+
+      # # This is for diagnostics
+      # - name: list directories
+      #   run: ls -l
+
+      # Create the release
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          draft: true
+          artifacts: "./${{  github.ref_name }}.zip, ./${{  github.ref_name }}.mltbx"
+          generateReleaseNotes: true
+          tag: ${{  github.ref_name }}


### PR DESCRIPTION
The tag driven action for releasing zip/ MLTBX is modified with the following changes:
1.	The Action is now release driven meaning it will executed once you publish a release
2.	It will only update the last published release with zip and MLTBX artifacts

The action is implemented in the file buildZipMLTBXReleaseDriven.yml. I have modified the original workflow file (buildZipMLTBX.yml) to be manually triggered to prevent it from executing when a tag is pushed.


"THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY."