### PR TITLE
Screen('DrawDots'): Only apply a margin to non-square dot types.

### DIFF
--- a/PsychSourceGL/Source/Common/Screen/SCREENDrawDots.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENDrawDots.c
@@ -91,6 +91,7 @@ char PointSmoothVertexShaderSrc[] =
 "/* delivers individual point size (diameter) information for each point.            */ \n"
 "\n"
 "uniform int useUnclampedFragColor;\n"
+"uniform int drawRoundDots;\n"
 "varying float pointSize;\n"
 "varying vec4 unclampedFragColor;\n"
 "\n"
@@ -111,7 +112,9 @@ char PointSmoothVertexShaderSrc[] =
 "    /* Point size comes via texture coordinate set 2: Make diameter 2 pixels bigger    */\n"
 "    /* than requested, to have some 1 pixel security margin around the dot, to avoid   */\n"
 "    /* cutoff artifacts for the rendered point-sprite quad. Compensate in frag-shader. */\n"
-"    pointSize = gl_MultiTexCoord2[0] + 2.0;\n"
+"    /* Only apply the margin to round dots. */\n"
+"    float margin = drawRoundDots > 0 ? 2.0 : 0.0;\n"
+"    pointSize = gl_MultiTexCoord2[0] + margin;\n"
 "    gl_PointSize = pointSize;\n"
 "}\n\0";
 


### PR DESCRIPTION
Only round dots get trimmed in the fragment shader, and so dot_type=4 was left with too much padding from the vertex shader.

Tested on Ubuntu 20.04 + AMD Pro W5500 + Octave with this script: https://gist.github.com/aforren1/31028d18da246db26bae207a009d23b0. The first row of dots is `dot_type=0`, the second row is `dot_type=4`, and the third is `dot_type=3`.

The first image is the old behavior with 10px dots, and the second is the new.

![old_10px](https://github.com/kleinerm/Psychtoolbox-3/assets/4573394/4db63fb9-bae9-4be0-9f52-10296a272024)
![new_10px](https://github.com/kleinerm/Psychtoolbox-3/assets/4573394/ea27ddf4-a97b-4a95-8611-dcf70de84bf5)

