### PR TITLE
Python: Add a long_description to appease Python's publishing tools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -309,6 +309,7 @@ ext_modules.append(IOPort)
 setup (name = 'psychtoolbox',
        version = version,
        description = 'Pieces of Psychtoolbox-3 ported to CPython.',
+       long_description = 'Pieces of Psychtoolbox-3 ported to CPython.',
        author = 'Mario Kleiner',
        author_email = 'mario.kleiner.de@gmail.com',
        url = 'http://psychtoolbox.org',


### PR DESCRIPTION
It seems this is unintentional and may be fixed one day, but twine (the tool that uploads packages to PyPI) now fails if the long_description is not set. See https://github.com/pypa/twine/issues/960 for context.