### PR TITLE
GetGitPath(): Fix path to git on MS-Windows.

### DIFF
--- a/Psychtoolbox/PsychOneliners/GetGitPath.m
+++ b/Psychtoolbox/PsychOneliners/GetGitPath.m
@@ -65,7 +65,7 @@ else
     elseif IsWin
         [returnCode,gitpath] = system('where git');
         if returnCode==0
-            gitpath = strtrim(gitpath);
+            gitpath = [fileparts(strtrim(gitpath)) filesep];
         else
             % failed, clear whatever the command returned
             gitpath = '';


### PR DESCRIPTION
'where git' returns the path including 'git.exe', and `GetGITInfo()` only expects the path minus the executable. This chops the 'git.exe' off.

Successfully tested on Win11 + git from https://www.git-scm.com/. Originally, it would fail at the `git describe` step because the concatenated command was '"C:\Program Files\Git\cmd\git.exe"git'.

Unrelated, but any reason the Mac/Linux branch of `GetGITInfo()` couldn't be replaced with `which git` instead of checking predefined paths?