### PR TITLE
Procedural noise: Update (classic) Perlin noise to latest version.

### DIFF
--- a/PsychSourceGL/License.txt
+++ b/PsychSourceGL/License.txt
@@ -236,7 +236,7 @@
 % license. See file: PsychDemos/OpenGL4MatlabDemos/GLSLDemoShaders/3Dlabs-License.txt
 %
 % GLSL shaders for Perlin noise: - MIT license, Copyright (C) 2011 Ashima Arts and
-%                                  Copyright (c) 2011 Stefan Gustavson.
+%                                  Copyright (c) 2011-2025 Stefan Gustavson.
 %                                  Files from https://github.com/stegu/webgl-noise
 %                                  With minimal modifications for PTB by Mario Kleiner.
 %

--- a/PsychSourceGL/License.txt
+++ b/PsychSourceGL/License.txt
@@ -237,7 +237,7 @@
 %
 % GLSL shaders for Perlin noise: - MIT license, Copyright (C) 2011 Ashima Arts and
 %                                  Copyright (c) 2011 Stefan Gustavson.
-%                                  Files from https://github.com/ashima/webgl-noise
+%                                  Files from https://github.com/stegu/webgl-noise
 %                                  With minimal modifications for PTB by Mario Kleiner.
 %
 % All other OpenGL GLSL shaders - MIT license : Mario Kleiner.

--- a/Psychtoolbox/License.txt
+++ b/Psychtoolbox/License.txt
@@ -236,8 +236,8 @@
 % license. See file: PsychDemos/OpenGL4MatlabDemos/GLSLDemoShaders/3Dlabs-License.txt
 %
 % GLSL shaders for Perlin noise: - MIT license, Copyright (C) 2011 Ashima Arts and
-%                                  Copyright (c) 2011 Stefan Gustavson.
-%                                  Files from https://github.com/ashima/webgl-noise
+%                                  Copyright (c) 2011-2025 Stefan Gustavson.
+%                                  Files from https://github.com/stegu/webgl-noise
 %                                  With minimal modifications for PTB by Mario Kleiner.
 %
 % All other OpenGL GLSL shaders - MIT license : Mario Kleiner.

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/BasicPerlinNoiseShader.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/BasicPerlinNoiseShader.frag.txt
@@ -3,7 +3,7 @@
  * and friends to generate procedural noise textures.
  *
  * This is a thin wrapper around the fast procedural perlin noise
- * generation code from https://github.com/ashima/webgl-noise
+ * generation code from https://github.com/stegu/webgl-noise
  *
  * (c) 2011-2012 Mario Kleiner. This is licensed to you under the MIT license.
  *

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/ClassicPerlinNoiseLib.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/ClassicPerlinNoiseLib.frag.txt
@@ -1,15 +1,15 @@
 //
 // GLSL textureless classic 3D noise "cnoise",
 // with an RSL-style periodic variant "pnoise".
-// Author:  Stefan Gustavson (stefan.gustavson@liu.se)
-// Version: 2011-10-11
+// Author:  Stefan Gustavson (stefan.gustavson@gmail.com)
+// Version: 2024-11-07
 //
 // Many thanks to Ian McEwan of Ashima Arts for the
 // ideas for permutation and gradient selection.
 //
 // Copyright (c) 2011 Stefan Gustavson. All rights reserved.
 // Distributed under the MIT license. See LICENSE file.
-// https://github.com/ashima/webgl-noise
+// https://github.com/stegu/webgl-noise
 //
 
 vec3 mod289(vec3 x)
@@ -24,7 +24,7 @@ vec4 mod289(vec4 x)
 
 vec4 permute(vec4 x)
 {
-  return mod289(((x*34.0)+1.0)*x);
+  return mod289(((x*34.0)+10.0)*x);
 }
 
 vec4 taylorInvSqrt(vec4 r)
@@ -40,12 +40,12 @@ vec3 fade(vec3 t) {
 /* float cnoise(vec3 P) */
 float perlinNoise(vec3 P)
 {
-  vec3 Pi0 = floor(P); /* Integer part for indexing */
-  vec3 Pi1 = Pi0 + vec3(1.0); /* Integer part + 1 */
+  vec3 Pi0 = floor(P); // Integer part for indexing
+  vec3 Pi1 = Pi0 + vec3(1.0); // Integer part + 1
   Pi0 = mod289(Pi0);
   Pi1 = mod289(Pi1);
-  vec3 Pf0 = fract(P); /* Fractional part for interpolation */
-  vec3 Pf1 = Pf0 - vec3(1.0); /* Fractional part - 1.0 */
+  vec3 Pf0 = fract(P); // Fractional part for interpolation
+  vec3 Pf1 = Pf0 - vec3(1.0); // Fractional part - 1.0
   vec4 ix = vec4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
   vec4 iy = vec4(Pi0.yy, Pi1.yy);
   vec4 iz0 = Pi0.zzzz;
@@ -81,24 +81,16 @@ float perlinNoise(vec3 P)
   vec3 g111 = vec3(gx1.w,gy1.w,gz1.w);
 
   vec4 norm0 = taylorInvSqrt(vec4(dot(g000, g000), dot(g010, g010), dot(g100, g100), dot(g110, g110)));
-  g000 *= norm0.x;
-  g010 *= norm0.y;
-  g100 *= norm0.z;
-  g110 *= norm0.w;
   vec4 norm1 = taylorInvSqrt(vec4(dot(g001, g001), dot(g011, g011), dot(g101, g101), dot(g111, g111)));
-  g001 *= norm1.x;
-  g011 *= norm1.y;
-  g101 *= norm1.z;
-  g111 *= norm1.w;
 
-  float n000 = dot(g000, Pf0);
-  float n100 = dot(g100, vec3(Pf1.x, Pf0.yz));
-  float n010 = dot(g010, vec3(Pf0.x, Pf1.y, Pf0.z));
-  float n110 = dot(g110, vec3(Pf1.xy, Pf0.z));
-  float n001 = dot(g001, vec3(Pf0.xy, Pf1.z));
-  float n101 = dot(g101, vec3(Pf1.x, Pf0.y, Pf1.z));
-  float n011 = dot(g011, vec3(Pf0.x, Pf1.yz));
-  float n111 = dot(g111, Pf1);
+  float n000 = norm0.x * dot(g000, Pf0);
+  float n010 = norm0.y * dot(g010, vec3(Pf0.x, Pf1.y, Pf0.z));
+  float n100 = norm0.z * dot(g100, vec3(Pf1.x, Pf0.yz));
+  float n110 = norm0.w * dot(g110, vec3(Pf1.xy, Pf0.z));
+  float n001 = norm1.x * dot(g001, vec3(Pf0.xy, Pf1.z));
+  float n011 = norm1.y * dot(g011, vec3(Pf0.x, Pf1.yz));
+  float n101 = norm1.z * dot(g101, vec3(Pf1.x, Pf0.y, Pf1.z));
+  float n111 = norm1.w * dot(g111, Pf1);
 
   vec3 fade_xyz = fade(Pf0);
   vec4 n_z = mix(vec4(n000, n100, n010, n110), vec4(n001, n101, n011, n111), fade_xyz.z);

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PerlinNoiseLib.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PerlinNoiseLib.frag.txt
@@ -2,11 +2,12 @@
 // Description : Array and textureless GLSL 2D/3D/4D simplex 
 //               noise functions.
 //      Author : Ian McEwan, Ashima Arts.
-//  Maintainer : ijm
-//     Lastmod : 20110822 (ijm)
+//  Maintainer : stegu
+//     Lastmod : 20201014 (stegu)
 //     License : Copyright (C) 2011 Ashima Arts. All rights reserved.
 //               Distributed under the MIT License. See LICENSE file.
 //               https://github.com/ashima/webgl-noise
+//               https://github.com/stegu/webgl-noise
 // 
 
 vec3 mod289(vec3 x) {
@@ -18,7 +19,7 @@ vec4 mod289(vec4 x) {
 }
 
 vec4 permute(vec4 x) {
-     return mod289(((x*34.0)+1.0)*x);
+     return mod289(((x*34.0)+10.0)*x);
 }
 
 vec4 taylorInvSqrt(vec4 r)
@@ -32,40 +33,40 @@ float perlinNoise(vec3 v)
   const vec2  C = vec2(1.0/6.0, 1.0/3.0) ;
   const vec4  D = vec4(0.0, 0.5, 1.0, 2.0);
 
-  /* First corner */
+// First corner
   vec3 i  = floor(v + dot(v, C.yyy) );
   vec3 x0 =   v - i + dot(i, C.xxx) ;
 
-  /* Other corners */
+// Other corners
   vec3 g = step(x0.yzx, x0.xyz);
   vec3 l = 1.0 - g;
   vec3 i1 = min( g.xyz, l.zxy );
   vec3 i2 = max( g.xyz, l.zxy );
 
-  /*   x0 = x0 - 0.0 + 0.0 * C.xxx;
+  //   x0 = x0 - 0.0 + 0.0 * C.xxx;
   //   x1 = x0 - i1  + 1.0 * C.xxx;
   //   x2 = x0 - i2  + 2.0 * C.xxx;
-  //   x3 = x0 - 1.0 + 3.0 * C.xxx; */
+  //   x3 = x0 - 1.0 + 3.0 * C.xxx;
   vec3 x1 = x0 - i1 + C.xxx;
-  vec3 x2 = x0 - i2 + C.yyy; /* 2.0*C.x = 1/3 = C.y */
-  vec3 x3 = x0 - D.yyy;      /* -1.0+3.0*C.x = -0.5 = -D.y */
+  vec3 x2 = x0 - i2 + C.yyy; // 2.0*C.x = 1/3 = C.y
+  vec3 x3 = x0 - D.yyy;      // -1.0+3.0*C.x = -0.5 = -D.y
 
-  /* Permutations */
+// Permutations
   i = mod289(i); 
   vec4 p = permute( permute( permute( 
              i.z + vec4(0.0, i1.z, i2.z, 1.0 ))
            + i.y + vec4(0.0, i1.y, i2.y, 1.0 )) 
            + i.x + vec4(0.0, i1.x, i2.x, 1.0 ));
 
-  /* Gradients: 7x7 points over a square, mapped onto an octahedron.
-  // The ring size 17*17 = 289 is close to a multiple of 49 (49*6 = 294) */
-  float n_ = 0.142857142857; /* 1.0/7.0 */
+// Gradients: 7x7 points over a square, mapped onto an octahedron.
+// The ring size 17*17 = 289 is close to a multiple of 49 (49*6 = 294)
+  float n_ = 0.142857142857; // 1.0/7.0
   vec3  ns = n_ * D.wyz - D.xzx;
 
-  vec4 j = p - 49.0 * floor(p * ns.z * ns.z);  /*  mod(p,7*7) */
+  vec4 j = p - 49.0 * floor(p * ns.z * ns.z);  //  mod(p,7*7)
 
   vec4 x_ = floor(j * ns.z);
-  vec4 y_ = floor(j - 7.0 * x_ );    /* mod(j,N) */
+  vec4 y_ = floor(j - 7.0 * x_ );    // mod(j,N)
 
   vec4 x = x_ *ns.x + ns.yyyy;
   vec4 y = y_ *ns.x + ns.yyyy;
@@ -74,8 +75,8 @@ float perlinNoise(vec3 v)
   vec4 b0 = vec4( x.xy, y.xy );
   vec4 b1 = vec4( x.zw, y.zw );
 
-  /* vec4 s0 = vec4(lessThan(b0,0.0))*2.0 - 1.0; */
-  /* vec4 s1 = vec4(lessThan(b1,0.0))*2.0 - 1.0; */
+  //vec4 s0 = vec4(lessThan(b0,0.0))*2.0 - 1.0;
+  //vec4 s1 = vec4(lessThan(b1,0.0))*2.0 - 1.0;
   vec4 s0 = floor(b0)*2.0 + 1.0;
   vec4 s1 = floor(b1)*2.0 + 1.0;
   vec4 sh = -step(h, vec4(0.0));
@@ -88,16 +89,16 @@ float perlinNoise(vec3 v)
   vec3 p2 = vec3(a1.xy,h.z);
   vec3 p3 = vec3(a1.zw,h.w);
 
-  /* Normalise gradients */
+//Normalise gradients
   vec4 norm = taylorInvSqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2, p2), dot(p3,p3)));
   p0 *= norm.x;
   p1 *= norm.y;
   p2 *= norm.z;
   p3 *= norm.w;
 
-  /* Mix final noise value */
-  vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
+// Mix final noise value
+  vec4 m = max(0.5 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
   m = m * m;
-  return 42.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1), 
+  return 105.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1), 
                                 dot(p2,x2), dot(p3,x3) ) );
   }


### PR DESCRIPTION
There were some changes in the upstream shaders cerca 2021 that appear to visibly improve randomness/reduce banding artifacts. There may also be a minor performance improvement because some math was simplified, but may be system-dependent (I only saw 10s of microseconds changes).

The new files were taken from https://github.com/stegu/webgl-noise, which is more or less the same as the upstream ashima/webgl-noise except the author's email is up to date.

Here are the first frames from `ProceduralNoiseDemo`, for comparison:

| | old | new |
|:-------------------------:|:-------------------------:|:-------------------------:|
classic | <img width="256" height="256" alt="old-classic" src="https://github.com/user-attachments/assets/9af8c9f9-647f-48c9-95a8-e6f88b26259b" /> | <img width="256" height="256" alt="new-classic" src="https://github.com/user-attachments/assets/5842fb89-29b8-4bfa-819f-68a1892c6be1" /> |
simplex | <img width="256" height="256" alt="old-perlin" src="https://github.com/user-attachments/assets/f9d2d181-ea5e-4622-9db4-305d620d7f9a" /> | <img width="256" height="256" alt="new-perlin" src="https://github.com/user-attachments/assets/7f3cd2ae-98cf-47c9-837c-260ac7543da1" /> |

Tested on Debian 12 + Octave + AMD Radeon Pro W5500.